### PR TITLE
fixes #1 -- memory error in MFD flow accumulation with travis-CI

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,8 @@ Release History
 
 Unreleased Changes
 ------------------
+* Fixed a memory error issue that could occur on multiple flow direction flow
+  accumulation calculations.
 * Added PEP518-compatible build dependencies to ``pyproject.toml``, which has
   been added to source distributions of pygeoprocessing.
 * Added an out-of-core high performance raster percentile function at


### PR DESCRIPTION
This PR fixes the memory error by avoiding tracing branching flow paths that can occur in MFD by marking pixels already visited in a temporary raster.