### PR TITLE
Bugfix/osx catalina compile

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,13 +32,13 @@ jobs:
     - name: Install PyGeoprocessing (Windows)
       if: matrix.os == 'windows-latest'
       env:
-          GDAL_DATA: "$env.CONDA\\Library\\share\\gdal\\"
-      shell: powershell
+          GDAL_DATA: "%CONDA%\\Library\\share\\gdal\\"
+      shell: cmd
       # Replace numpy and scipy with PyPI versions to circumvent import issue.
       # https://stackoverflow.com/a/37110747/299084
       run: |
           pip install --upgrade numpy scipy
-          python setup.py install
+          %CONDA%\python setup.py install
 
     - name: Install PyGeoprocessing (Linux)
       if: matrix.os == 'ubuntu-16.04'

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install PyGeoprocessing (Windows)
       if: matrix.os == 'windows-latest'
       env:
-          - GDAL_DATA: "$env.CONDA\\Library\\share\\gdal\\"
+          GDAL_DATA: "$env.CONDA\\Library\\share\\gdal\\"
       shell: powershell
       # Replace numpy and scipy with PyPI versions to circumvent import issue.
       # https://stackoverflow.com/a/37110747/299084

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     env:
         PACKAGES: "shapely numpy scipy cython rtree!=0.9.1 pytest flake8 gdal<3"
     strategy:
-      fail-fast: true
+      fail-fast: false
       max-parallel: 4
       matrix:
         python-version: [3.6, 3.7]
@@ -36,8 +36,7 @@ jobs:
       # Replace numpy and scipy with PyPI versions to circumvent import issue.
       # https://stackoverflow.com/a/37110747/299084
       run: |
-          conda install $PACKAGES
-          $CONDA/python -m pip install -I numpy scipy
+          $CONDA/python -m pip install $PACKAGES
           $CONDA/python setup.py install
 
     - name: Install PyGeoprocessing (Linux)

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -6,13 +6,13 @@ jobs:
   Test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       max-parallel: 4
       matrix:
         python-version: [3.6, 3.7]
         os: [ubuntu-16.04, windows-latest, macos-latest]
         env:
             - GDAL: "gdal>=2.2,<3"
-            - CFLAGS: "-stdlib=libc++"
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -6,7 +6,7 @@ jobs:
   Test:
     runs-on: ${{ matrix.os }}
     env:
-        PACKAGES: "shapely numpy scipy cython rtree pytest flake8 gdal<3"
+        PACKAGES: "shapely numpy scipy cython 'rtree!=0.9.1' pytest flake8 gdal<3"
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - os: macos-latest
             env: 
-                - CFLAGS "-stdlib=libc++"
+                - CFLAGS: "-stdlib=libc++"
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -29,11 +29,11 @@ jobs:
           conda install -y $GDAL shapely numpy scipy shapely cython rtree pytest
           conda upgrade -y pip setuptools
 
-    - name: Install PyGeoprocessing (mac)
+    - name: Install PyGeoprocessing (mac only)
       if: matrix.os == 'macos-latest'
       run: CFLAGS="-stdlib=libc++" python setup.py install
 
-    - name: Install PyGeoprocessing
+    - name: Install PyGeoprocessing (non-mac)
       if: matrix.os != 'macos-latest'
       run: python setup.py install
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         python-version: [3.5, 3.6, 3.7]
         os: [ubuntu-16.04, windows-latest, macos-latest]
-        env: 
+        env:
             - GDAL: "gdal>=2.4.0,<3"
             - GDAL: "gdal>=3"
 
@@ -25,8 +25,10 @@ jobs:
         conda-channels: ''
     - name: Install dependencies
       shell: bash
+      env: ${{ matrix.env }}
       run: conda install $GDAL shapely numpy scipy shapely cython rtree pytest
     - name: Install PyGeoprocessing
+      run: python setup.py install
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,12 +32,15 @@ jobs:
     - name: Install PyGeoprocessing (Mac)
       if: matrix.os == 'macos-latest'
       shell: bash
-      run: CFLAGS="-stdlib=libc++" python setup.py install
+      run: CFLAGS="-stdlib=libc++ -mmacosx-version-min=10.9" python setup.py install
 
     - name: Install PyGeoprocessing (Windows)
       if: matrix.os == 'windows-latest'
       shell: cmd
+      # Replace numpy and scipy with PyPI versions to circumvent import issue.
+      # https://stackoverflow.com/a/37110747/299084
       run: |
+          pip install --upgrade numpy scipy
           python setup.py install
 
     - name: Install PyGeoprocessing (Linux)

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,7 +22,6 @@ jobs:
       with:
         update-conda: false
         python-version: ${{ matrix.python-version }}
-        conda-channels: 'conda-forge'
     - name: Install dependencies
       shell: bash
       env: ${{ matrix.env }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,7 +12,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.6, 3.7]
-        os: [ubuntu-16.04, windows-latest]
+        os: [ubuntu-16.04, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v1
@@ -39,8 +39,8 @@ jobs:
           $CONDA/python -m pip install $PACKAGES
           $CONDA/python setup.py install
 
-    - name: Install PyGeoprocessing (Linux)
-      if: matrix.os == 'ubuntu-16.04'
+    - name: Install PyGeoprocessing (Linux, Mac)
+      if: matrix.os != 'windows-latest'
       run: |
           conda install $PACKAGES
           python setup.py install

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,19 +31,18 @@ jobs:
 
     - name: Install PyGeoprocessing (Mac)
       if: matrix.os == 'macos-latest'
+      shell: bash
       run: CFLAGS="-stdlib=libc++" python setup.py install
 
     - name: Install PyGeoprocessing (Windows)
       if: matrix.os == 'windows-latest'
-      shell: bash
+      shell: cmd
       run: |
-          which python
           python setup.py install
 
     - name: Install PyGeoprocessing (Linux)
       if: matrix.os == 'ubuntu-16.04'
       run: |
-          which python
           python setup.py install
 
     - name: Lint with flake8

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,7 +12,7 @@ jobs:
         python-version: [3.6, 3.7]
         os: [ubuntu-16.04, windows-latest, macos-latest]
         env:
-            - GDAL: "gdal>=2.4.0,<3"
+            - GDAL: "gdal>=2.2,<3"
             - GDAL: "gdal>=3"
 
     steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -6,7 +6,7 @@ jobs:
   Test:
     runs-on: ${{ matrix.os }}
     env:
-        PACKAGES: "shapely numpy scipy cython 'rtree!=0.9.1' pytest flake8 gdal<3"
+        PACKAGES: "shapely numpy scipy cython rtree!=0.9.1 pytest flake8 gdal<3"
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,11 +12,7 @@ jobs:
         os: [ubuntu-16.04, windows-latest, macos-latest]
         env:
             - GDAL: "gdal>=2.2,<3"
-        include:
-          - os: macos-latest
-            python-version: [3.6, 3.7]
-            env: 
-                - CFLAGS: "-stdlib=libc++"
+            - CFLAGS: "-stdlib=libc++"
 
     steps:
     - uses: actions/checkout@v1
@@ -29,7 +25,9 @@ jobs:
     - name: Install dependencies
       shell: bash
       env: ${{ matrix.env }}
-      run: conda install -y $GDAL shapely numpy scipy shapely cython rtree pytest
+      run: |
+          conda install -y $GDAL shapely numpy scipy shapely cython rtree pytest
+          conda upgrade -y pip setuptools
     - name: Install PyGeoprocessing
       env: ${{ matrix.env }}
       run: python setup.py install

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -28,9 +28,15 @@ jobs:
       run: |
           conda install -y $GDAL shapely numpy scipy shapely cython rtree pytest
           conda upgrade -y pip setuptools
+
+    - name: Install PyGeoprocessing (mac)
+      if: {{ matrix.os == 'macos-latest' }}
+      run: CFLAGS="-stdlib=libc++" python setup.py install
+
     - name: Install PyGeoprocessing
-      env: ${{ matrix.env }}
+      if: {{ matrix.os != 'macos-latest' }}
       run: python setup.py install
+
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,6 +22,7 @@ jobs:
       with:
         update-conda: false
         python-version: ${{ matrix.python-version }}
+        conda-channels: defaults
     - name: Install dependencies
       shell: bash
       env: ${{ matrix.env }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     env:
         PACKAGES: "shapely numpy scipy cython rtree!=0.9.1 pytest flake8 gdal<3"
     strategy:
-      fail-fast: false
+      fail-fast: true
       max-parallel: 4
       matrix:
         python-version: [3.6, 3.7]
@@ -37,7 +37,7 @@ jobs:
       # https://stackoverflow.com/a/37110747/299084
       run: |
           conda install $PACKAGES
-          $CONDA/python -m pip install numpy scipy
+          $CONDA/python -m pip install -I numpy scipy
           $CONDA/python setup.py install
 
     - name: Install PyGeoprocessing (Linux)

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -37,7 +37,7 @@ jobs:
       # Replace numpy and scipy with PyPI versions to circumvent import issue.
       # https://stackoverflow.com/a/37110747/299084
       run: |
-          pip install --upgrade numpy scipy
+          pip install --upgrade -I numpy scipy
           %CONDA%\python setup.py install
 
     - name: Install PyGeoprocessing (Linux)

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,6 +14,7 @@ jobs:
             - GDAL: "gdal>=2.2,<3"
         include:
           - os: macos-latest
+            python-version: [3.6, 3.7]
             env: 
                 - CFLAGS: "-stdlib=libc++"
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -5,14 +5,14 @@ on: [push, pull_request]
 jobs:
   Test:
     runs-on: ${{ matrix.os }}
+    env:
+        PACKAGES: shapely numpy scipy cython rtree pytest flake8 "gdal>=2.2,<3"
     strategy:
       fail-fast: false
       max-parallel: 4
       matrix:
         python-version: [3.6, 3.7]
         os: [ubuntu-16.04, windows-latest]
-        env:
-            - GDAL: "gdal>=2.2,<3"
 
     steps:
     - uses: actions/checkout@v1
@@ -24,30 +24,29 @@ jobs:
         conda-channels: defaults
     - name: Install dependencies
       shell: bash
-      env: ${{ matrix.env }}
-      run: |
-          conda install -y $GDAL shapely numpy scipy shapely cython rtree pytest
-          conda upgrade -y pip setuptools
+      run: conda upgrade -y pip setuptools
 
     - name: Install PyGeoprocessing (Windows)
       if: matrix.os == 'windows-latest'
       env:
-          GDAL_DATA: "%CONDA%\\Library\\share\\gdal\\"
-      shell: cmd
+          PIP_EXTRA_INDEX_URL: "http://pypi.naturalcapitalproject.org/simple/"
+          PIP_TRUSTED_HOST: "pypi.naturalcapitalproject.org"
+          PIP_PREFER_BINARY: 1
+      shell: bash
       # Replace numpy and scipy with PyPI versions to circumvent import issue.
       # https://stackoverflow.com/a/37110747/299084
       run: |
-          pip install --upgrade -I numpy scipy
-          %CONDA%\python setup.py install
+          $CONDA/python -m pip install $PACKAGES
+          $CONDA/python setup.py install
 
     - name: Install PyGeoprocessing (Linux)
       if: matrix.os == 'ubuntu-16.04'
       run: |
+          conda install $PACKAGES
           python setup.py install
 
     - name: Lint with flake8
       run: |
-        pip install flake8
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -6,7 +6,7 @@ jobs:
   Test:
     runs-on: ${{ matrix.os }}
     env:
-        PACKAGES: shapely numpy scipy cython rtree pytest flake8 "gdal<3"
+        PACKAGES: "shapely numpy scipy cython rtree pytest flake8 gdal<3"
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.6, 3.7]
-        os: [ubuntu-16.04, windows-latest, macos-latest]
+        os: [ubuntu-16.04, windows-latest]
         env:
             - GDAL: "gdal>=2.2,<3"
 
@@ -29,14 +29,11 @@ jobs:
           conda install -y $GDAL shapely numpy scipy shapely cython rtree pytest
           conda upgrade -y pip setuptools
 
-    - name: Install PyGeoprocessing (Mac)
-      if: matrix.os == 'macos-latest'
-      shell: bash
-      run: CFLAGS="-stdlib=libc++ -mmacosx-version-min=10.9" python setup.py install
-
     - name: Install PyGeoprocessing (Windows)
       if: matrix.os == 'windows-latest'
-      shell: cmd
+      env:
+          - GDAL_DATA: "$env.CONDA\\Library\\share\\gdal\\"
+      shell: powershell
       # Replace numpy and scipy with PyPI versions to circumvent import issue.
       # https://stackoverflow.com/a/37110747/299084
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -6,7 +6,7 @@ jobs:
   Test:
     runs-on: ${{ matrix.os }}
     env:
-        PACKAGES: shapely numpy scipy cython rtree pytest flake8 "gdal>=2.2,<3"
+        PACKAGES: shapely numpy scipy cython rtree pytest flake8 "gdal<3"
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.5, 3.6, 3.7]
+        python-version: [3.6, 3.7]
         os: [ubuntu-16.04, windows-latest, macos-latest]
         env:
             - GDAL: "gdal>=2.4.0,<3"

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -36,7 +36,8 @@ jobs:
       # Replace numpy and scipy with PyPI versions to circumvent import issue.
       # https://stackoverflow.com/a/37110747/299084
       run: |
-          $CONDA/python -m pip install $PACKAGES
+          conda install $PACKAGES
+          $CONDA/python -m pip install numpy scipy
           $CONDA/python setup.py install
 
     - name: Install PyGeoprocessing (Linux)

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 
 jobs:
   Test:
-
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 4
@@ -13,7 +12,6 @@ jobs:
         os: [ubuntu-16.04, windows-latest, macos-latest]
         env:
             - GDAL: "gdal>=2.2,<3"
-            - GDAL: "gdal>=3"
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -30,11 +30,11 @@ jobs:
           conda upgrade -y pip setuptools
 
     - name: Install PyGeoprocessing (mac)
-      if: {{ matrix.os == 'macos-latest' }}
+      if: matrix.os == 'macos-latest'
       run: CFLAGS="-stdlib=libc++" python setup.py install
 
     - name: Install PyGeoprocessing
-      if: {{ matrix.os != 'macos-latest' }}
+      if: matrix.os != 'macos-latest'
       run: python setup.py install
 
     - name: Lint with flake8

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,0 +1,38 @@
+name: Test PyGeoprocessing
+
+on: [push, pull_request]
+
+jobs:
+  Test:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.5, 3.6, 3.7]
+        os: [ubuntu-16.04, windows-latest, macos-latest]
+        env: 
+            - GDAL: "gdal>=2.4.0,<3"
+            - GDAL: "gdal>=3"
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: setup-conda
+      uses: s-weigand/setup-conda@v1.0.0
+      with:
+        update-conda: true
+        python-version: ${{ matrix.python-version }}
+        conda-channels: ''
+    - name: Install dependencies
+      shell: bash
+      run: conda install $GDAL shapely numpy scipy shapely cython rtree pytest
+    - name: Install PyGeoprocessing
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -29,13 +29,22 @@ jobs:
           conda install -y $GDAL shapely numpy scipy shapely cython rtree pytest
           conda upgrade -y pip setuptools
 
-    - name: Install PyGeoprocessing (mac only)
+    - name: Install PyGeoprocessing (Mac)
       if: matrix.os == 'macos-latest'
       run: CFLAGS="-stdlib=libc++" python setup.py install
 
-    - name: Install PyGeoprocessing (non-mac)
-      if: matrix.os != 'macos-latest'
-      run: python setup.py install
+    - name: Install PyGeoprocessing (Windows)
+      if: matrix.os == 'windows-latest'
+      shell: bash
+      run: |
+          which python
+          python setup.py install
+
+    - name: Install PyGeoprocessing (Linux)
+      if: matrix.os == 'ubuntu-16.04'
+      run: |
+          which python
+          python setup.py install
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,13 +20,13 @@ jobs:
     - name: setup-conda
       uses: s-weigand/setup-conda@v1.0.0
       with:
-        update-conda: true
+        update-conda: false
         python-version: ${{ matrix.python-version }}
-        conda-channels: ''
+        conda-channels: 'conda-forge'
     - name: Install dependencies
       shell: bash
       env: ${{ matrix.env }}
-      run: conda install $GDAL shapely numpy scipy shapely cython rtree pytest
+      run: conda install -y $GDAL shapely numpy scipy shapely cython rtree pytest
     - name: Install PyGeoprocessing
       run: python setup.py install
     - name: Lint with flake8

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,6 +12,10 @@ jobs:
         os: [ubuntu-16.04, windows-latest, macos-latest]
         env:
             - GDAL: "gdal>=2.2,<3"
+        include:
+          - os: macos-latest
+            env: 
+                - CFLAGS "-stdlib=libc++"
 
     steps:
     - uses: actions/checkout@v1
@@ -26,6 +30,7 @@ jobs:
       env: ${{ matrix.env }}
       run: conda install -y $GDAL shapely numpy scipy shapely cython rtree pytest
     - name: Install PyGeoprocessing
+      env: ${{ matrix.env }}
       run: python setup.py install
     - name: Lint with flake8
       run: |

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,10 @@ Unreleased Changes
 * Fixed a compilation issue on Mac OS X Catalina related to the compilation
   of a template in the file iteration component of the out-of-core percentile
   function.
+* Resolved a compilation issue on Mac OS X (Mavericks and later) where
+  pygeoprocessing would not compile unless some additional compiler and linker
+  flags were provided.  These are now accounted for in the package's compilation
+  steps in ``setup.py``.
 
 1.9.0 (2019-10-22)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+Unreleased Changes
+------------------
+* Fixed a compilation issue on Mac OS X Catalina related to the compilation
+  of a template in the file iteration component of the out-of-core percentile
+  function.
+
 1.9.0 (2019-10-22)
 ------------------
 * Fixed a memory error issue that could occur on multiple flow direction flow

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # This file records the packages and requirements needed in order for
 # pygeoprocessing to work as expected.
 
-GDAL>=2.4.0
+GDAL>=2.2.0
 numpy>=1.10.1
 scipy>=0.14.1,!=0.19.1
 Shapely>=1.6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # This file records the packages and requirements needed in order for
 # pygeoprocessing to work as expected.
 
-GDAL>=2.4.0,<3.0
+GDAL>=2.4.0
 numpy>=1.10.1
 scipy>=0.14.1,!=0.19.1
 Shapely>=1.6.4

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 """setup.py module for PyGeoprocessing."""
+import platform
+
 import numpy
 from setuptools.extension import Extension
 from setuptools import setup
@@ -11,6 +13,14 @@ _REQUIREMENTS = [
 LONG_DESCRIPTION = open('README.rst').read().format(
     requirements='\n'.join(['    ' + r for r in _REQUIREMENTS]))
 LONG_DESCRIPTION += '\n' + open('HISTORY.rst').read() + '\n'
+
+# Since OSX Mavericks, the stdlib has been renamed.  So if we're on OSX, we
+# need to be sure to define which standard c++ library to use.  I don't have
+# access to a pre-Mavericks mac, so hopefully this won't break on someone's
+# older system.  Tested and it works on Mac OSX Catalina.
+compiler_and_linker_args = []
+if platform.system() == 'Darwin':
+    compiler_and_linker_args = ['-stdlib=libc++']
 
 setup(
     name='pygeoprocessing',
@@ -57,6 +67,8 @@ setup(
             include_dirs=[
                 numpy.get_include(),
                 'src/pygeoprocessing/routing'],
+            extra_compile_args=compiler_and_linker_args,
+            extra_link_args=compiler_and_linker_args,
             language="c++",
         ),
         Extension(
@@ -65,14 +77,18 @@ setup(
             include_dirs=[
                 numpy.get_include(),
                 'src/pygeoprocessing/routing'],
+            extra_compile_args=compiler_and_linker_args,
+            extra_link_args=compiler_and_linker_args,
             language="c++",
         ),
         Extension(
-             "pygeoprocessing.geoprocessing_core",
-             sources=[
-                 'src/pygeoprocessing/geoprocessing_core.pyx'],
-             include_dirs=[numpy.get_include()],
-             language="c++"
+            "pygeoprocessing.geoprocessing_core",
+            sources=[
+                'src/pygeoprocessing/geoprocessing_core.pyx'],
+            include_dirs=[numpy.get_include()],
+            extra_compile_args=compiler_and_linker_args,
+            extra_link_args=compiler_and_linker_args,
+            language="c++"
         ),
     ]
 )

--- a/src/pygeoprocessing/geoprocessing_core.pyx
+++ b/src/pygeoprocessing/geoprocessing_core.pyx
@@ -15,8 +15,7 @@ cimport cython
 from cython.operator cimport dereference as deref
 from cython.operator cimport preincrement as inc
 from libcpp.vector cimport vector
-from libcpp.algorithm cimport push_heap
-from libcpp.algorithm cimport pop_heap
+cimport libcpp.algorithm
 from libc.stdio cimport FILE
 from libc.stdio cimport fopen
 from libc.stdio cimport fwrite
@@ -39,6 +38,18 @@ cdef extern from "FastFileIterator.h" nogil:
         size_t size()
     int FastFileIteratorCompare[DATA_T](FastFileIterator[DATA_T]*,
                                         FastFileIterator[DATA_T]*)
+
+# This resolves an issue on Mac OS X Catalina where cimporting ``push_heap``
+# and ``pop_heap`` from the Standard Library would cause compilation to fail
+# with an error message about the candidate function template not being
+# viable.  The SO answer to a related question 
+# (https://stackoverflow.com/a/57586789/299084) suggests a workaround: don't
+# tell Cython that we have a template function.  Using ``...`` here allows
+# us to not have to specify all of the types for which we need a working
+# ``push_heap`` and ``pop_heap``.
+cdef extern from "<algorithm>" namespace "std":
+    void push_heap(...)
+    void pop_heap(...)
 
 @cython.boundscheck(False)
 @cython.wraparound(False)

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2587,8 +2587,7 @@ class PyGeoprocessing10(unittest.TestCase):
         # the sides and realizing diagonals got subtracted twice
         expected_result = test_value * (
             n_pixels ** 2 * 9 - n_pixels * 4 * 3 + 4)
-        self.assertAlmostEqual(numpy.sum(target_array), expected_result,
-                               places=3)
+        numpy.testing.assert_allclose(numpy.sum(target_array), expected_result)
 
     def test_convolve_2d_multiprocess(self):
         """PGP.geoprocessing: test convolve 2d (multiprocess)."""
@@ -2625,8 +2624,7 @@ class PyGeoprocessing10(unittest.TestCase):
         # the sides and realizing diagonals got subtracted twice
         expected_result = test_value * (
             n_pixels ** 2 * 9 - n_pixels * 4 * 3 + 4)
-        self.assertAlmostEqual(numpy.sum(target_array), expected_result,
-                               places=3)
+        numpy.testing.assert_allclose(numpy.sum(target_array), expected_result)
 
     def test_convolve_2d_normalize_ignore_nodata(self):
         """PGP.geoprocessing: test convolve 2d w/ normalize and ignore."""
@@ -2659,8 +2657,8 @@ class PyGeoprocessing10(unittest.TestCase):
         target_band = None
         target_raster = None
         expected_result = test_value * n_pixels ** 2
-        self.assertAlmostEqual(numpy.sum(target_array), expected_result,
-                               places=4)
+        numpy.testing.assert_allclose(numpy.sum(target_array),
+                                      expected_result)
 
     def test_convolve_2d_ignore_nodata(self):
         """PGP.geoprocessing: test convolve 2d w/ normalize and ignore."""
@@ -2836,8 +2834,8 @@ class PyGeoprocessing10(unittest.TestCase):
         # calculate expected result by adding up all squares, subtracting off
         # the sides and realizing diagonals got subtracted twice
         expected_result = test_value * (n_pixels ** 2)
-        self.assertAlmostEqual(numpy.sum(target_array), expected_result,
-                               places=3)
+        numpy.testing.assert_allclose(numpy.sum(target_array),
+                                      expected_result)
 
     def test_calculate_slope(self):
         """PGP.geoprocessing: test calculate slope."""

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2835,7 +2835,7 @@ class PyGeoprocessing10(unittest.TestCase):
         # the sides and realizing diagonals got subtracted twice
         expected_result = test_value * (n_pixels ** 2)
         numpy.testing.assert_allclose(numpy.sum(target_array),
-                                      expected_result)
+                                      expected_result, rtol=1e-6)
 
     def test_calculate_slope(self):
         """PGP.geoprocessing: test calculate slope."""

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -3,6 +3,7 @@ import time
 import tempfile
 import os
 import unittest
+import unittest.mock
 import shutil
 import types
 import importlib
@@ -13,7 +14,6 @@ from osgeo import osr
 import numpy
 import scipy.ndimage
 import shapely.geometry
-import mock
 
 
 def passthrough(x):
@@ -121,7 +121,7 @@ class PyGeoprocessing10(unittest.TestCase):
         from pkg_resources import DistributionNotFound
         import pygeoprocessing
 
-        with mock.patch('pygeoprocessing.pkg_resources.get_distribution',
+        with unittest.mock.patch('pygeoprocessing.pkg_resources.get_distribution',
                         side_effect=DistributionNotFound('pygeoprocessing')):
             with self.assertRaises(RuntimeError):
                 # RuntimeError is a side effect of `import pygeoprocessing`,
@@ -3013,7 +3013,7 @@ class PyGeoprocessing10(unittest.TestCase):
             # Patching the function that makes a logger callback so that
             # it will raise an exception (ZeroDivisionError in this case,
             # but any exception should do).
-            with mock.patch(
+            with unittest.mock.patch(
                     'pygeoprocessing.geoprocessing._make_logger_callback',
                     return_value=lambda x, y, z: 1/0.):
                 pygeoprocessing.rasterize(

--- a/tests/test_sampledata.py
+++ b/tests/test_sampledata.py
@@ -1,6 +1,7 @@
 # encoding=UTF-8
 """Tests for the creation of geospatial sample data."""
 import unittest
+import unittest.mock
 import os
 import subprocess
 import shutil
@@ -11,7 +12,6 @@ from osgeo import ogr
 from osgeo import osr
 import numpy
 from shapely.geometry import Polygon
-import mock
 
 
 class RasterCreationTest(unittest.TestCase):
@@ -325,7 +325,7 @@ class GISBrowserTest(unittest.TestCase):
         from pygeoprocessing.testing.sampledata import \
             open_files_in_gis_browser
         file_list = ['foo']
-        with mock.patch('subprocess.call'):
+        with unittest.mock.patch('subprocess.call'):
             open_files_in_gis_browser(file_list)
             self.assertTrue(subprocess.call.called)
             self.assertEqual(subprocess.call.call_args[0][0],
@@ -339,13 +339,13 @@ class CleanupTest(unittest.TestCase):
     def test_cleanup_dir(self):
         """Verify shutil.rmtree is called by cleanup()."""
         from pygeoprocessing.testing.sampledata import cleanup
-        with mock.patch('shutil.rmtree'):
+        with unittest.mock.patch('shutil.rmtree'):
             cleanup('/')
             self.assertTrue(shutil.rmtree.called)
 
     def test_cleanup_file(self):
         """Verify os.remove is called by cleanup()."""
         from pygeoprocessing.testing.sampledata import cleanup
-        with mock.patch('os.remove'):
+        with unittest.mock.patch('os.remove'):
             cleanup('/foo')
             self.assertTrue(os.remove.called)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,6 +1,7 @@
 # coding=UTF-8
 """Tests for ``pygeoprocessing.testing`` functionality."""
 import unittest
+import unittest.mock
 import tempfile
 import os
 import shutil
@@ -12,7 +13,6 @@ import json
 import numpy
 from osgeo import ogr
 from shapely.geometry import Point, LineString
-import mock
 
 
 class JSONTests(unittest.TestCase):
@@ -582,7 +582,7 @@ class DigestEquality(unittest.TestCase):
         # Simulate being on Windows.
         # On *NIX systems, this shouldn't affect the output files at all, since
         # we're replacing os.sep ('/' on *NIX) with '/'.
-        with mock.patch('platform.system', lambda: 'Windows'):
+        with unittest.mock.patch('platform.system', lambda: 'Windows'):
             # Just to verify that sys.platform() is currently set to Windows.
             self.assertEqual(platform.system(), 'Windows')
             checksum_folder(sample_folder, checksum_file, style='GNU')
@@ -734,7 +734,7 @@ class SCMTest(unittest.TestCase):
         nonexistent_folder = os.path.join(self.workspace, 'dir_not_found')
         remote_path = 'svn://foo'
 
-        with mock.patch('subprocess.call'):
+        with unittest.mock.patch('subprocess.call'):
             checkout_svn(nonexistent_folder, remote_path)
             self.assertTrue(subprocess.call.called)
             self.assertEqual(subprocess.call.call_args[0][0],
@@ -745,7 +745,7 @@ class SCMTest(unittest.TestCase):
         """Verify that SVN update is called with the correct parameters."""
         from pygeoprocessing.testing.scm import checkout_svn
 
-        with mock.patch('subprocess.call'):
+        with unittest.mock.patch('subprocess.call'):
             checkout_svn(self.workspace, 'svn://foo')
             self.assertTrue(subprocess.call.called)
             self.assertEqual(subprocess.call.call_args[0][0],
@@ -755,7 +755,7 @@ class SCMTest(unittest.TestCase):
         """Verify SVN update -r <rev> is called with the correct params."""
         from pygeoprocessing.testing.scm import checkout_svn
 
-        with mock.patch('subprocess.call'):
+        with unittest.mock.patch('subprocess.call'):
             checkout_svn(self.workspace, 'svn://foo', rev='25')
             self.assertTrue(subprocess.call.called)
             self.assertEqual(subprocess.call.call_args[0][0],


### PR DESCRIPTION
This PR fixes the OSX Catalina issue (noted in issue #9 ), as well as a couple of other related things:

* The definition of `CFLAGS=-stdlib=libc++` at the command-line is no longer required, as `setup.py` now defines this environment variable if it's needed.
* I bumped down the GDAL requirement in `requirements.txt`, as we no longer default to using ZSTD compression.
* `mock` import has been replaced by `unittest.mock`, as mock has been distributed as part of the standard library since Python 3.3.

Also, this PR includes the changes proposed in https://github.com/natcap/pygeoprocessing/pull/10, but also adds testing on Mac.