### PR TITLE
Bugfix/geoprocessing 18 remove multiprocessing

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,7 @@
 Release History
 ===============
 
-Unreleased Changes
+1.9.1 (2019-12-19)
 ------------------
 * Fixed a compilation issue on Mac OS X Catalina related to the compilation
   of a template in the file iteration component of the out-of-core percentile

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,8 @@ Unreleased Changes
   pygeoprocessing would not compile unless some additional compiler and linker
   flags were provided.  These are now accounted for in the package's compilation
   steps in ``setup.py``.
+* ``pygeoprocessing.symbolic.evaluate_raster_calculator_expression``
+  no longer depends on ``sympy`` for its expression evaluation.
 
 1.9.0 (2019-10-22)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,13 @@
 Release History
 ===============
 
+Unreleased Changes
+------------------
+* Removed the ``multiprocessing`` dependency to avoid an occasional deadlock 
+  that occurred on Mac OS X during ``align_and_resize_raster_stack``. 
+  That function now operates serially, but multithreading can be used by
+  passing ``gdal_warp_options``.
+
 1.9.1 (2019-12-19)
 ------------------
 * Fixed a compilation issue on Mac OS X Catalina related to the compilation

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,51 @@
 .. default-role:: code
 
-PyGeoprocessing has migrated to github
-======================================
+About PyGeoprocessing
+=====================
 
-https://github.com/natcap/pygeoprocessing
+PyGeoprocessing is a Python/Cython based library that provides a set of
+commonly used raster, vector, and hydrological operations for GIS processing.
+Similar functionality can be found in ArcGIS/QGIS raster algebra, ArcGIS zonal
+statistics, and ArcGIS/GRASS/TauDEM hydrological routing routines.
+
+PyGeoprocessing is developed at the Natural Capital Project to create a
+programmable, open source, and free Python based GIS processing library to
+support the InVEST toolset.  PyGeoprocessing's design prioritizes
+computation and memory efficient runtimes, easy installation and cross
+compatibility with other open source and proprietary software licenses, and a
+simplified set of orthogonal GIS processing routines that interact with GIS
+data via filename. Specifically the functionally provided by PyGeoprocessing
+includes:
+
+* a suite of raster manipulation functions (warp, align, raster calculator,
+  reclassification, distance transform, convolution, and fast iteration)
+* a suite of vector based manipulation function (zonal statistics,
+  rasterization, interpolate points, reprojection, and disjoint polygon sets)
+* a simplified hydrological routing library (D8inf/MFD flow direction,
+  plateau drainage, weighted and unweighted flow accumulation, and weighted
+  and unweighted flow distance)
+
+Installing PyGeoprocessing
+==========================
+
+.. code-block:: console
+
+    $ pip install pygeoprocessing
+
+If you `import pygeoprocessing` and see a `ValueError: numpy.dtype has the
+wrong size, try recompiling`, this is the result of a version compatibility
+issue with the numpy API in the precompiled pygeoprocessing binaries.
+The solution is to recompile pygeoprocessing on your computer:
+
+.. code-block:: console
+
+    $ pip uninstall -y pygeoprocessing
+    $ pip install pygeoprocessing --no-deps --no-binary :all:
+
+Requirements
+------------
+
+Note the pip-installable requirements in `requirements.txt` are for best
+results, but older package versions may also work. If necessary,
+PyGeoprocessing can be installed without dependencies with `pip install
+--no-deps`.

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -13,8 +13,6 @@ import functools
 import math
 import time
 import tempfile
-import multiprocessing
-import multiprocessing.pool
 import threading
 import collections
 import shutil


### PR DESCRIPTION
This PR removes the `multiprocessing` dependency in pygeoprocessing. The motivating issue was to avoid an occasional deadlock  that occurred on Mac OS X during ``align_and_resize_raster_stack``. See issue #18 .   

Also, in `convolve_d2`, some `multiprocessing` utilities were replaced with analogous `queue` and `threading` library objects. 

I'm not sure why the README.rst appears in this diff -- that change should already be on develop -- but it probably has to do with a rebase I did on my fork in order to fix incorrect issue numbers in my commit messages.