### PR TITLE
avoiding a problematic shapely version. #25.

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -5,8 +5,7 @@ on: [push, pull_request]
 jobs:
   Test:
     runs-on: ${{ matrix.os }}
-    env:
-        PACKAGES: "shapely numpy scipy cython rtree!=0.9.1 pytest flake8 gdal<3"
+
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -36,13 +35,13 @@ jobs:
       # Replace numpy and scipy with PyPI versions to circumvent import issue.
       # https://stackoverflow.com/a/37110747/299084
       run: |
-          $CONDA/python -m pip install $PACKAGES
+          $CONDA/python -m pip install -r requirements.txt
           $CONDA/python setup.py install
 
     - name: Install PyGeoprocessing (Linux, Mac)
       if: matrix.os != 'windows-latest'
       run: |
-          conda install $PACKAGES
+          conda install --file requirements.txt
           python setup.py install
 
     - name: Lint with flake8

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -5,7 +5,8 @@ on: [push, pull_request]
 jobs:
   Test:
     runs-on: ${{ matrix.os }}
-
+    env:
+        PACKAGES: "pytest flake8"
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -36,12 +37,14 @@ jobs:
       # https://stackoverflow.com/a/37110747/299084
       run: |
           $CONDA/python -m pip install -r requirements.txt
+          $CONDA/python -m pip install $PACKAGES
           $CONDA/python setup.py install
 
     - name: Install PyGeoprocessing (Linux, Mac)
       if: matrix.os != 'windows-latest'
       run: |
           conda install --file requirements.txt
+          conda install $PACKAGES
           python setup.py install
 
     - name: Lint with flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 GDAL>=2.2.0
 numpy>=1.10.1
 scipy>=0.14.1,!=0.19.1
-Shapely>=1.6.4
+Shapely>=1.6.4,!=1.7.0
 future
 Cython
 Rtree>=0.8.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # This file records the packages and requirements needed in order for
 # pygeoprocessing to work as expected.
 
-GDAL>=2.2.0
+GDAL>=2.2.0,<3.0
 numpy>=1.10.1
 scipy>=0.14.1,!=0.19.1
 Shapely>=1.6.4,!=1.7.0


### PR DESCRIPTION
A PR to avoid dependency on `shapely 1.7.0` Please see issue #25 for a description of the problem.

And this PR also now modifies the github Actions pipeline to install dependencies from requirements.txt