### PR TITLE
Updating changelog for 1.9.2 release

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,11 @@
 Release History
 ===============
 
-1.9.1 (2019-12-19)
+..
+  Unreleased Changes
+  -----------------
+
+1.9.2 (2020-02-06)
 ------------------
 * Removed the ``multiprocessing`` dependency to avoid an occasional deadlock 
   that occurred on Mac OS X during ``align_and_resize_raster_stack``. 


### PR DESCRIPTION
This PR updates the changelog for the 1.9.2 release.

Unlike with our old release process, I can't include a tag in the PR process itself, so once this is approved and merged, I'll create a new release object in the upstream repository.