### PR TITLE
force a specific package index url for shapely on Windows.

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,7 +35,10 @@ jobs:
       shell: bash
       # Replace numpy and scipy with PyPI versions to circumvent import issue.
       # https://stackoverflow.com/a/37110747/299084
+      #
+      # Shapely 1.7.0 on PyPI has GEOS cdll issues in some environments. Gohlke builds work.
       run: |
+          $CONDA/python -m pip install shapely --index-url http://pypi.naturalcapitalproject.org/simple/ -c requirements.txt
           $CONDA/python -m pip install -r requirements.txt
           $CONDA/python -m pip install $PACKAGES
           $CONDA/python setup.py install

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 GDAL>=2.2.0,<3.0
 numpy>=1.10.1
 scipy>=0.14.1,!=0.19.1
-Shapely>=1.6.4,!=1.7.0
+Shapely>=1.6.4
 future
 Cython
 Rtree>=0.8.3


### PR DESCRIPTION
It's not Shapely version 1.7.0 that's a problem for Windows, it's just the build on PyPI. So here's a solution for forcing the installation from a different package index. See issue #25 