### PR TITLE
Bugfix/update links from bitbucket to GitHub

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ Release History
 
 Unreleased Changes
 ------------------
+* Updated ``setup.py`` to point the URL project link to the project's new
+  home on GitHub.
 * Updated ``MANIFEST.in`` to only include files that should be there in the
   pygeoprocessing source distribution.  This fixes an issue where files
   matching a variety of extensions anywhere in the pygeoprocessing directory

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     maintainer='Rich Sharp',
     maintainer_email='richpsharp@gmail.com',
-    url='https://bitbucket.org/natcap/pygeoprocessing',
+    url='https://github.com/natcap/pygeoprocessing',
     packages=[
         'pygeoprocessing',
         'pygeoprocessing.routing',


### PR DESCRIPTION
This is a trivial PR to update the project link in `setup.py` to point to the repo's new home on github.