### PR TITLE
Updating checkout to v2. Fixes #36

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,11 @@ jobs:
         os: [ubuntu-16.04, windows-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+          # Fetch all history so that setuptool_scm can build the correct version string.
+          fetch-depth: 0
+
     - name: setup-conda
       uses: s-weigand/setup-conda@v1.0.0
       with:


### PR DESCRIPTION
This PR updates the checkout step on our test actions job to use the `v2` checkout version.