### PR TITLE
Automatically PR new commits on master into each open release branch

### DIFF
--- a/.github/workflows/auto-pr-from-master-into-releases.yml
+++ b/.github/workflows/auto-pr-from-master-into-releases.yml
@@ -26,12 +26,13 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  PR_BODY_FILE=pr_body.txt
-                  envsubst ci/bugfix-release-pr-body.md > $PR_BODY_FILE
-
                   BRANCHES=$(git ls-remote --heads origin | grep release | cut -d '/' -f 3-)
                   for RELEASE_BRANCH in `echo $BRANCHES`
                   do
+                      PR_BODY_FILE=pr_body.txt
+                      envsubst ci/bugfix-release-pr-body.md > $PR_BODY_FILE
+                      cat $PR_BODY_FILE  # for debugging
+
                       hub pull-request \
                           --base $GITHUB_REPOSITORY:$SOURCE_BRANCH \
                           --head $GITHUB_REPOSITORY:$RELEASE_BRANCH \

--- a/.github/workflows/auto-pr-from-master-into-releases.yml
+++ b/.github/workflows/auto-pr-from-master-into-releases.yml
@@ -1,13 +1,14 @@
 name: PR changes on master into release branches
 env:
-    SOURCE_BRANCH: feature/auto-pr-on-commit-to-master
+    SOURCE_BRANCH: master
 on:
     # This workflow should trigger when changes are pushed to master.
     # We expect this will happen when PRs into master are merged and also as
     # part of the automated bugfix release process.
     push:
         branches:
-            - feature/auto-pr-on-commit-to-master
+            # ${{ env.SOURCE_BRANCH }} does not seem to work here.
+            - master
 
 jobs:
     create-pr:

--- a/.github/workflows/auto-pr-from-master-into-releases.yml
+++ b/.github/workflows/auto-pr-from-master-into-releases.yml
@@ -26,6 +26,7 @@ jobs:
               shell: bash
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  SOURCE_BRANCH: ${{ env.SOURCE_BRANCH }}
               run: |
                   set -x
                   BRANCHES=$(git ls-remote --heads origin | grep release | cut -d '/' -f 3-)
@@ -33,7 +34,7 @@ jobs:
                   ERRORSPRESENT=0
                   for BRANCH in $BRANCHES
                   do
-                      RELEASE_BRANCH=$BRANCH  # needed for envsubst
+                      export RELEASE_BRANCH=$BRANCH  # needed for envsubst
                       PR_BODY_FILE=pr_body.txt
                       cat ci/bugfix-release-pr-body.md | envsubst > $PR_BODY_FILE
                       cat $PR_BODY_FILE  # for debugging

--- a/.github/workflows/auto-pr-from-master-into-releases.yml
+++ b/.github/workflows/auto-pr-from-master-into-releases.yml
@@ -39,8 +39,8 @@ jobs:
                       cat $PR_BODY_FILE  # for debugging
 
                       hub pull-request \
-                          --base $GITHUB_REPOSITORY:$SOURCE_BRANCH \
-                          --head $GITHUB_REPOSITORY:$RELEASE_BRANCH \
+                          --head $GITHUB_REPOSITORY:$SOURCE_BRANCH \
+                          --base $GITHUB_REPOSITORY:$RELEASE_BRANCH \
                           --reviewer "natcap/software-team" \
                           --assign "natcap/software-team" \
                           --file $PR_BODY_FILE || ERRORSPRESENT=$(($ERRORSPRESENT | $?))

--- a/.github/workflows/auto-pr-from-master-into-releases.yml
+++ b/.github/workflows/auto-pr-from-master-into-releases.yml
@@ -33,7 +33,7 @@ jobs:
                   for RELEASE_BRANCH in `echo $BRANCHES`
                   do
                       PR_BODY_FILE=pr_body.txt
-                      envsubst ci/bugfix-release-pr-body.md > $PR_BODY_FILE
+                      cat ci/bugfix-release-pr-body.md | envsubst > $PR_BODY_FILE
                       cat $PR_BODY_FILE  # for debugging
 
                       hub pull-request \

--- a/.github/workflows/auto-pr-from-master-into-releases.yml
+++ b/.github/workflows/auto-pr-from-master-into-releases.yml
@@ -30,8 +30,9 @@ jobs:
                   set -x
                   BRANCHES=$(git ls-remote --heads origin | grep release | cut -d '/' -f 3-)
                   echo $BRANCHES  # debugging
-                  for RELEASE_BRANCH in `echo $BRANCHES`
+                  for BRANCH in $BRANCHES
                   do
+                      RELEASE_BRANCH=$BRANCH  # needed for envsubst
                       PR_BODY_FILE=pr_body.txt
                       cat ci/bugfix-release-pr-body.md | envsubst > $PR_BODY_FILE
                       cat $PR_BODY_FILE  # for debugging

--- a/.github/workflows/auto-pr-from-master-into-releases.yml
+++ b/.github/workflows/auto-pr-from-master-into-releases.yml
@@ -30,7 +30,8 @@ jobs:
                   SOURCE_BRANCH: ${{ env.SOURCE_BRANCH }}
               run: |
                   set -x
-                  BRANCHES=$(git ls-remote --heads origin | grep release | cut -d '/' -f 3-)
+                  # Using grep with pattern ^release filters out any autorelease branches.
+                  BRANCHES=$(git ls-remote --heads origin | cut -d '/' -f 3- | grep ^release)
                   echo $BRANCHES  # debugging
                   ERRORSPRESENT=0
                   for BRANCH in $BRANCHES

--- a/.github/workflows/auto-pr-from-master-into-releases.yml
+++ b/.github/workflows/auto-pr-from-master-into-releases.yml
@@ -7,7 +7,7 @@ on:
     # part of the automated bugfix release process.
     push:
         branches:
-            - ${{ env.SOURCE_BRANCH }}
+            - feature/auto-pr-on-commit-to-master
 
 jobs:
     create-pr:

--- a/.github/workflows/auto-pr-from-master-into-releases.yml
+++ b/.github/workflows/auto-pr-from-master-into-releases.yml
@@ -1,0 +1,41 @@
+name: PR changes on master into release branches
+on:
+    # This workflow should trigger when changes are pushed to master.
+    # We expect this will happen when PRs into master are merged and also as
+    # part of the automated bugfix release process.
+    push:
+        branches:
+            - master
+
+jobs:
+    create-pr:
+        name: PR master into release/**
+        runs-on: ubuntu-latest
+        env:
+            SOURCE_BRANCH: master
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+            - run: git fetch origin +refs/tags/*:refs/tags/*
+
+            # Needed for envsubst
+            - run: sudo apt-get update && sudo apt-get install gettext-base
+
+            - name: Open a PR into each open release branch
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  PR_BODY_FILE=pr_body.txt
+                  envsubst ci/bugfix-release-pr-body.md > $PR_BODY_FILE
+
+                  BRANCHES=$(git ls-remote --heads origin | grep release | cut -d '/' -f 3-)
+                  for RELEASE_BRANCH in `echo $BRANCHES`
+                  do
+                      hub pull-request \
+                          --base $GITHUB_REPOSITORY:$SOURCE_BRANCH \
+                          --head $GITHUB_REPOSITORY:$RELEASE_BRANCH \
+                          --reviewer "natcap/software-team" \
+                          --assign "natcap/software-team" \
+                          --file $PR_BODY_FILE
+                  done

--- a/.github/workflows/auto-pr-from-master-into-releases.yml
+++ b/.github/workflows/auto-pr-from-master-into-releases.yml
@@ -23,10 +23,11 @@ jobs:
             - run: sudo apt-get update && sudo apt-get install gettext-base
 
             - name: Open a PR into each open release branch
-              shell: bash -x
+              shell: bash
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
+                  set -x
                   BRANCHES=$(git ls-remote --heads origin | grep release | cut -d '/' -f 3-)
                   echo $BRANCHES  # debugging
                   for RELEASE_BRANCH in `echo $BRANCHES`

--- a/.github/workflows/auto-pr-from-master-into-releases.yml
+++ b/.github/workflows/auto-pr-from-master-into-releases.yml
@@ -30,6 +30,7 @@ jobs:
                   set -x
                   BRANCHES=$(git ls-remote --heads origin | grep release | cut -d '/' -f 3-)
                   echo $BRANCHES  # debugging
+                  ERRORSPRESENT=0
                   for BRANCH in $BRANCHES
                   do
                       RELEASE_BRANCH=$BRANCH  # needed for envsubst
@@ -42,5 +43,11 @@ jobs:
                           --head $GITHUB_REPOSITORY:$RELEASE_BRANCH \
                           --reviewer "natcap/software-team" \
                           --assign "natcap/software-team" \
-                          --file $PR_BODY_FILE
+                          --file $PR_BODY_FILE || ERRORSPRESENT=$(($ERRORSPRESENT | $?))
                   done
+
+                  if [[ $ERRORSPRESENT -gt 0 ]]
+                  then
+                      echo "At least one of the PRs failed and might need to be revisited."
+                      exit 1
+                  fi

--- a/.github/workflows/auto-pr-from-master-into-releases.yml
+++ b/.github/workflows/auto-pr-from-master-into-releases.yml
@@ -5,7 +5,7 @@ on:
     # part of the automated bugfix release process.
     push:
         branches:
-            - master
+            - feature/auto-pr-on-commit-to-master
 
 jobs:
     create-pr:

--- a/.github/workflows/auto-pr-from-master-into-releases.yml
+++ b/.github/workflows/auto-pr-from-master-into-releases.yml
@@ -7,7 +7,7 @@ on:
     # part of the automated bugfix release process.
     push:
         branches:
-            # ${{ env.SOURCE_BRANCH }} does not seem to work here.
+            # The context variable ${{ env.SOURCE_BRANCH }} does not seem to work here.
             - master
 
 jobs:

--- a/.github/workflows/auto-pr-from-master-into-releases.yml
+++ b/.github/workflows/auto-pr-from-master-into-releases.yml
@@ -1,18 +1,18 @@
 name: PR changes on master into release branches
+env:
+    SOURCE_BRANCH: feature/auto-pr-on-commit-to-master
 on:
     # This workflow should trigger when changes are pushed to master.
     # We expect this will happen when PRs into master are merged and also as
     # part of the automated bugfix release process.
     push:
         branches:
-            - feature/auto-pr-on-commit-to-master
+            - ${{ env.SOURCE_BRANCH }}
 
 jobs:
     create-pr:
         name: PR master into release/**
         runs-on: ubuntu-latest
-        env:
-            SOURCE_BRANCH: master
         steps:
             - uses: actions/checkout@v2
               with:

--- a/.github/workflows/auto-pr-from-master-into-releases.yml
+++ b/.github/workflows/auto-pr-from-master-into-releases.yml
@@ -23,10 +23,12 @@ jobs:
             - run: sudo apt-get update && sudo apt-get install gettext-base
 
             - name: Open a PR into each open release branch
+              shell: bash -x
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   BRANCHES=$(git ls-remote --heads origin | grep release | cut -d '/' -f 3-)
+                  echo $BRANCHES  # debugging
                   for RELEASE_BRANCH in `echo $BRANCHES`
                   do
                       PR_BODY_FILE=pr_body.txt

--- a/.github/workflows/auto-pr-from-master-into-releases.yml
+++ b/.github/workflows/auto-pr-from-master-into-releases.yml
@@ -38,11 +38,14 @@ jobs:
                       cat ci/bugfix-release-pr-body.md | envsubst > $PR_BODY_FILE
                       cat $PR_BODY_FILE  # for debugging
 
+                      # This PR will be assigned to $GITHUB_ACTOR, which should be
+                      # the person who merged the PR that caused this commit to be
+                      # created.  Others could of course be assigned later.
                       hub pull-request \
                           --head $GITHUB_REPOSITORY:$SOURCE_BRANCH \
                           --base $GITHUB_REPOSITORY:$RELEASE_BRANCH \
-                          --reviewer "natcap/software-team" \
-                          --assign "natcap/software-team" \
+                          --reviewer "$GITHUB_ACTOR" \
+                          --assign "$GITHUB_ACTOR" \
                           --file $PR_BODY_FILE || ERRORSPRESENT=$(($ERRORSPRESENT | $?))
                   done
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,9 @@ Release History
 
 Unreleased Changes
 ------------------
+* When new Pull Requests are merged into ``master``, GitHub actions will
+  now create a PR from master into each open release branch in the
+  destination repository.
 * Adding a GitHub Actions-based build job for building wheels and a source
   distribution for a given commit of pygeoprocessing.
 * Updated ``setup.py`` to point the URL project link to the project's new

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,9 +4,6 @@ Release History
 
 Unreleased Changes
 ------------------
-* When new Pull Requests are merged into ``master``, GitHub actions will
-  now create a PR from master into each open release branch in the
-  destination repository.
 * Adding a GitHub Actions-based build job for building wheels and a source
   distribution for a given commit of pygeoprocessing.
 * Updated ``setup.py`` to point the URL project link to the project's new

--- a/ci/bugfix-release-pr-body.md
+++ b/ci/bugfix-release-pr-body.md
@@ -3,31 +3,41 @@ AUTO: merge $RELEASE_BRANCH into $SOURCE_BRANCH
 This PR was automatically generated in response to a push to `master`,
 and is a chance to review any changes that will be included in the release
 branch before merging.  Under most circumstances, this PR will probably be
-a formality.  However, there are a few cases where we may need to be some
+a formality.  However, there are a few cases where we may need to do some
 extra work to make sure `$RELEASE_BRANCH` contains what it should after the
 merge:
 
-## If this PR causes a trivial merge conflict
+## There is a merge conflict in this PR
 
-Use the github merge conflict resolution editor to resolve the change and
-commit the change to a new branch, *not to master*.
+1. Leave a comment on this PR about the merge conflict and close the PR.
+2. In your fork, make a new `pr-resolution` branch off of `$SOURCE_BRANCH`:
+   ```shell
+   $ git checkout $SOURCE_BRANCH
+   $ git pull upstream $SOURCE_BRANCH  # Include the latest changes on the upstream master
+   $ git checkout -b pr-resolution
+   $ git merge $RELEASE_BRANCH
+   ```
+3. Resolve the conflicts locally
+4. Commit the changes to `pr-resolution`.
+5. Create a PR from `pr-resolution` into `$RELEASE_BRANCH`, and include a link
+   to the origin PR in the description.
 
-## If this PR causes a nontrivial merge conflict
+## This PR contains content that should not be in `$RELEASE_BRANCH`
 
-1. Decline this PR
-2. Make a new bugfix branch off of `master`
-3. Merge `$RELEASE_BRANCH` into the bugfix branch, resolving the conflict.
-4. PR the bugfix branch into `$RELEASE_BRANCH`
-
-## If this PR contains content that should not be in $RELEASE_BRANCH
-
-1. Decline this PR
-2. Make a new bugfix branch off of `master`
-3. Merge `$RELEASE_BRANCH` into the bugfix branch
-4. Handle the content that should not end up in `$RELEASE_BRANCH` however it
-   needs to be handled
-5. Commit the updated content
-6. PR the bugfix branch into `$RELEASE_BRANCH`
+1. Leave a comment on this PR about the content that should not be included
+   and close the PR.
+2. In your fork, make a new `pr-resolution` branch off of `$SOURCE_BRANCH`:
+   ```shell
+   $ git checkout $SOURCE_BRANCH
+   $ git pull upstream $SOURCE_BRANCH  # Include the latest changes on the upstream master
+   $ git checkout -b pr-resolution
+   $ git merge $RELEASE_BRANCH
+   ```
+3. Handle the content that should not end up in `$RELEASE_BRANCH` however it
+   needs to be handled.
+4. Commit the updated content to `pr-resolution`.
+5. Create a PR from `pr-resolution` into `$RELEASE_BRANCH`, and include a link
+   to the origin PR in the description.
 
 ## What happens if we accidentally merge something we shouldn't?
 
@@ -41,12 +51,13 @@ There are several possibilities for recovery if we get to such a state.
 
 ### Why was this PR created?
 
-Possible events that can trigger this include:
+The workflow defining this PR is located at
+`.github/workflows/auto-pr-from-master-into-releases.yml`.  In short, this PR
+was created because there was a push to `$SOURCE_BRANCH` that triggered this
+workflow.  Some events that can trigger this include:
 
-* Other pull requests for feature or bugfixes being merged into `master`
-* Automated bugfix releases
-* Any manual push to `master`, if ever that happens (which shouldn't be the
+* Other pull requests being merged into `$SOURCE_BRANCH`
+* Automated releases on `$SOURCE_BRANCH`
+* Any manual push to `$SOURCE_BRANCH`, if ever that happens (which shouldn't be the
   case given our branch protections)
 
-The workflow defining this PR is located at
-`.github/workflows/auto-pr-from-master-into-releases.yml`.

--- a/ci/bugfix-release-pr-body.md
+++ b/ci/bugfix-release-pr-body.md
@@ -21,6 +21,8 @@ merge:
 4. Commit the changes to `pr-resolution`.
 5. Create a PR from `pr-resolution` into `$RELEASE_BRANCH`, and include a link
    to the origin PR in the description.
+6. When the PR is complete, delete the `pr-resolution` branch.  That will
+   help us avoid confusion and extra work down the road when we do this again.
 
 ## This PR contains content that should not be in `$RELEASE_BRANCH`
 
@@ -38,6 +40,8 @@ merge:
 4. Commit the updated content to `pr-resolution`.
 5. Create a PR from `pr-resolution` into `$RELEASE_BRANCH`, and include a link
    to the origin PR in the description.
+6. When the PR is complete, delete the `pr-resolution` branch.  That will
+   help us avoid confusion and extra work down the road when we do this again.
 
 ## What happens if we accidentally merge something we shouldn't?
 

--- a/ci/bugfix-release-pr-body.md
+++ b/ci/bugfix-release-pr-body.md
@@ -1,4 +1,4 @@
-AUTO: merge $RELEASE_BRANCH into $SOURCE_BRANCH
+AUTO: merge $SOURCE_BRANCH into $RELEASE_BRANCH
 
 This PR was automatically generated in response to a push to `master`,
 and is a chance to review any changes that will be included in the release

--- a/ci/bugfix-release-pr-body.md
+++ b/ci/bugfix-release-pr-body.md
@@ -1,4 +1,4 @@
-Auto: include the latest changes from master into $RELEASE_BRANCH
+AUTO: merge $RELEASE_BRANCH into $SOURCE_BRANCH
 
 This PR was automatically generated in response to a push to `master`,
 and is a chance to review any changes that will be included in the release

--- a/ci/bugfix-release-pr-body.md
+++ b/ci/bugfix-release-pr-body.md
@@ -1,0 +1,52 @@
+Auto: include the latest changes from master into $RELEASE_BRANCH
+
+This PR was automatically generated in response to a push to `master`,
+and is a chance to review any changes that will be included in the release
+branch before merging.  Under most circumstances, this PR will probably be
+a formality.  However, there are a few cases where we may need to be some
+extra work to make sure `$RELEASE_BRANCH` contains what it should after the
+merge:
+
+## If this PR causes a trivial merge conflict
+
+Use the github merge conflict resolution editor to resolve the change and
+commit the change to a new branch, *not to master*.
+
+## If this PR causes a nontrivial merge conflict
+
+1. Decline this PR
+2. Make a new bugfix branch off of `master`
+3. Merge `$RELEASE_BRANCH` into the bugfix branch, resolving the conflict.
+4. PR the bugfix branch into `$RELEASE_BRANCH`
+
+## If this PR contains content that should not be in $RELEASE_BRANCH
+
+1. Decline this PR
+2. Make a new bugfix branch off of `master`
+3. Merge `$RELEASE_BRANCH` into the bugfix branch
+4. Handle the content that should not end up in `$RELEASE_BRANCH` however it
+   needs to be handled
+5. Commit the updated content
+6. PR the bugfix branch into `$RELEASE_BRANCH`
+
+## What happens if we accidentally merge something we shouldn't?
+
+There are several possibilities for recovery if we get to such a state.
+
+1. A merge can be undone through the github interface if the error is caught
+   directly after the PR is merged.
+2. If we're commits in past the erroneous merge, create a branch off of
+   `$RELEASE_BRANCH`, back out of the changes or edit files needed to resolve
+   the issue, and PR the branch back into `$RELEASE_BRANCH`.
+
+### Why was this PR created?
+
+Possible events that can trigger this include:
+
+* Other pull requests for feature or bugfixes being merged into `master`
+* Automated bugfix releases
+* Any manual push to `master`, if ever that happens (which shouldn't be the
+  case given our branch protections)
+
+The workflow defining this PR is located at
+`.github/workflows/auto-pr-from-master-into-releases.yml`.


### PR DESCRIPTION
This PR adds some automation so that whenever a new commit is made onto `master`, a new PR will be opened from `master` into each release branch.  This PR will be automatically assigned to the last committer on `master`, the team member who approved and merged the PR that triggered the automation.

The body of the PR will contain some explanatory text about what to do in case of merge conflict, and how to handle various fallback states.

For an example of what this looks like, take a look at [THIS BUILD](https://github.com/phargogh/pygeoprocessing/runs/590891592?check_suite_focus=true), which triggered [THIS PR](https://github.com/phargogh/pygeoprocessing/runs/590891592?check_suite_focus=true) and [THIS PR](https://github.com/phargogh/pygeoprocessing/pull/3).