### PR TITLE
Bugfix/convolve2 d 22 near zero error

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,6 +13,8 @@ Unreleased Changes
   pygeoprocessing source distribution.  This fixes an issue where files
   matching a variety of extensions anywhere in the pygeoprocessing directory
   might be included with the source distribution.
+* Added ``set_tol_to_zero`` to ``convolve_2d`` to allow for in-function masking
+  of near-zero results to be set to 0.0.
 
 1.9.2 (2020-02-06)
 ------------------

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2510,7 +2510,7 @@ def convolve_2d(
             # If the tolerance is set, set all absolute values less than this
             # to 0.0
             output_array[
-                numpy.isclose(output_array, atol=set_tol_to_zero)] = 0.0
+                numpy.isclose(output_array, 0.0, atol=set_tol_to_zero)] = 0.0
 
         target_band.WriteArray(
             output_array, xoff=index_dict['xoff'],


### PR DESCRIPTION
Fixes convolve 2d numerical error by providing a threshold that can be set with an absolute tolerance value.