### PR TITLE
Only auto-PRing master into release branches on upstream. Fixes #64

### DIFF
--- a/.github/workflows/auto-pr-from-master-into-releases.yml
+++ b/.github/workflows/auto-pr-from-master-into-releases.yml
@@ -12,6 +12,9 @@ on:
 
 jobs:
     create-pr:
+        # Only create a PR from master into release branches if we're on the
+        # main pygeoprocessing repository.
+        if: github.repository == 'natcap/pygeoprocessing'
         name: PR master into release/**
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -24,7 +24,7 @@ jobs:
       uses: goanpeca/setup-miniconda@v1.1.2
       with:
         activate-environment: pyenv
-        auto-update-conda: true 
+        auto-update-conda: false
         python-version: ${{ matrix.python-version }}
         channels: conda-forge, anaconda
     - name: Install dependencies


### PR DESCRIPTION
This PR patches something that should have been included https://github.com/natcap/pygeoprocessing/pull/53 but slipped my mind.  PRs from `master` into release branches will now only be created on the `natcap/pygeoprocessing` repository.  On forks, the action job will still appear in the listing, but it'll appear as 'skipped', and no PRs will be created.

Thanks @dcdenu4 for pointing this out!