### PR TITLE
Bugfix/convolve2 d 66 nodata undefined

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,9 @@ Unreleased Changes (2.0)
   Lat,Lon but we use osr.OAMS_TRADITIONAL_GIS_ORDER to swap to Lon,Lat.
 * Using osr.CreateCoordinateTransformation() instead of
   osr.CoordinateTransformation() as the GDAL 3 call.
+* Fixed a bug in convolve_2d that would not ``ignore_nodata`` if the signal
+  raster's nodata value was undefined. Changed the name of this flag to
+  ``ignore_nodata_and_edges`` to reflect its expected functionality.
 
 Unreleased Changes (master)
 ---------------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,8 +1,8 @@
 Release History
 ===============
 
-Unreleased Changes (2.0)
-------------------------
+Unreleased Changes
+------------------
 * Adding Python 3.8 support and dropping Python 3.6 support.
 * Adding GDAL 3 support and dropping GDAL 2 support. The only non-backwards
   compatible issue in GDAL 2 to GDAL 3 is the need to handle Axis Ordering with
@@ -15,9 +15,6 @@ Unreleased Changes (2.0)
 * Fixed a bug in convolve_2d that would not ``ignore_nodata`` if the signal
   raster's nodata value was undefined. Changed the name of this flag to
   ``ignore_nodata_and_edges`` to reflect its expected functionality.
-
-Unreleased Changes (master)
----------------------------
 * Warped signed byte rasters are now also signed byte rasters.
 * Adding a GitHub Actions-based build job for building wheels and a source
   distribution for a given commit of pygeoprocessing.

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2357,7 +2357,7 @@ def _next_regular(base):
 
 def convolve_2d(
         signal_path_band, kernel_path_band, target_path,
-        ignore_nodata=False, mask_nodata=True, normalize_kernel=False,
+        ignore_nodata_and_edges=False, mask_nodata=True, normalize_kernel=False,
         target_datatype=gdal.GDT_Float64,
         target_nodata=None, n_threads=1, working_dir=None,
         set_tol_to_zero=1e-8,
@@ -2377,9 +2377,15 @@ def convolve_2d(
             of signal with kernel.  Output will be a single band raster of
             same size and projection as ``signal_path_band``. Any nodata pixels
             that align with ``signal_path_band`` will be set to nodata.
-        ignore_nodata (boolean): If true, any pixels that are equal to
-            ``signal_path_band``'s nodata value are not included when averaging
-            the convolution filter.
+        ignore_nodata_and_edges (boolean): If true, any pixels that are equal
+            to ``signal_path_band``'s nodata value or signal pixels where the
+            kernel extends beyond the edge of the raster are not included when
+            averaging the convolution filter. This has the effect of
+            "spreading" the result as though nodata and edges beyond the bounds
+            of the raster are 0s. If set to false this tends to "pull" the
+            signal away from nodata holes or raster edges. Set this value
+            to ``True`` to avoid distortions signal values near edges for
+            large integrating kernels.
         normalize_kernel (boolean): If true, the result is divided by the
             sum of the kernel.
         mask_nodata (boolean): If true, ``target_path`` raster's output is
@@ -2447,7 +2453,7 @@ def convolve_2d(
 
     # if we're ignoring nodata, we need to make a parallel convolved signal
     # of the nodata mask
-    if s_nodata is not None and ignore_nodata:
+    if ignore_nodata_and_edges:
         mask_dir = tempfile.mkdtemp(dir=working_dir)
         mask_raster_path = os.path.join(mask_dir, 'convolved_mask.tif')
         new_raster_from_base(
@@ -2465,7 +2471,7 @@ def convolve_2d(
     kernel_nodata = kernel_raster_info['nodata'][0]
     kernel_sum = 0.0
     for _, kernel_block in iterblocks(kernel_path_band):
-        if kernel_nodata is not None and ignore_nodata:
+        if kernel_nodata is not None and ignore_nodata_and_edges:
             kernel_block[numpy.isclose(kernel_block, kernel_nodata)] = 0.0
         kernel_sum += numpy.sum(kernel_block)
 
@@ -2482,7 +2488,7 @@ def convolve_2d(
             target=_convolve_2d_worker,
             args=(
                 signal_path_band, kernel_path_band,
-                ignore_nodata, normalize_kernel,
+                ignore_nodata_and_edges, normalize_kernel,
                 work_queue, write_queue))
         worker.daemon = True
         worker.start()
@@ -2543,7 +2549,7 @@ def convolve_2d(
             output_array, xoff=index_dict['xoff'],
             yoff=index_dict['yoff'])
 
-        if s_nodata is not None and ignore_nodata:
+        if ignore_nodata_and_edges:
             # we'll need to save off the mask convolution so we can divide
             # it in total later
             current_mask = mask_band.ReadAsArray(**index_dict)
@@ -2569,7 +2575,7 @@ def convolve_2d(
         os.path.basename(target_path))
     target_band.FlushCache()
     target_raster.FlushCache()
-    if s_nodata is not None and ignore_nodata:
+    if ignore_nodata_and_edges:
         LOGGER.info(
             "need to normalize result so nodata values are not included")
         mask_pixels_processed = 0
@@ -2618,7 +2624,7 @@ def convolve_2d(
     gdal.Dataset.__swig_destroy__(target_raster)
     target_band = None
     target_raster = None
-    if s_nodata is not None and ignore_nodata:
+    if s_nodata is not None and ignore_nodata_and_edges:
         # there's a working directory only if we need to remember the nodata
         # pixels
         shutil.rmtree(mask_dir)

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2919,7 +2919,7 @@ class PyGeoprocessing10(unittest.TestCase):
         target_path = os.path.join(self.workspace_dir, 'target.tif')
         pygeoprocessing.convolve_2d(
             (signal_path, 1), (kernel_path, 1), target_path,
-            n_threads=1, ignore_nodata=False)
+            n_threads=1, ignore_nodata_and_edges=False)
         target_raster = gdal.OpenEx(target_path, gdal.OF_RASTER)
         target_band = target_raster.GetRasterBand(1)
         target_array = target_band.ReadAsArray()
@@ -2993,7 +2993,8 @@ class PyGeoprocessing10(unittest.TestCase):
         target_path = os.path.join(self.workspace_dir, 'target.tif')
         pygeoprocessing.convolve_2d(
             (signal_path, 1), (kernel_path, 1), target_path,
-            mask_nodata=False, ignore_nodata=True, normalize_kernel=True)
+            mask_nodata=False, ignore_nodata_and_edges=True,
+            normalize_kernel=True)
         target_raster = gdal.OpenEx(target_path, gdal.OF_RASTER)
         target_band = target_raster.GetRasterBand(1)
         target_array = target_band.ReadAsArray()
@@ -3027,7 +3028,7 @@ class PyGeoprocessing10(unittest.TestCase):
         target_path = os.path.join(self.workspace_dir, 'target.tif')
         pygeoprocessing.convolve_2d(
             (signal_path, 1), (kernel_path, 1), target_path,
-            ignore_nodata=True)
+            ignore_nodata_and_edges=True)
         target_raster = gdal.OpenEx(target_path, gdal.OF_RASTER)
         target_band = target_raster.GetRasterBand(1)
         target_array = target_band.ReadAsArray()


### PR DESCRIPTION
I changed the name of that parameter to be `ignore_nodata_and_edges` since that's really what it does, I fixed the places in the code that would incorrectly skip that functionality if the signal raster's nodata was None, added a test to cover it, and updated the history accordingly. 