### PR TITLE
fixes #37 just fixing the log and updating history

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,8 @@ Unreleased Changes
   might be included with the source distribution.
 * Added ``set_tol_to_zero`` to ``convolve_2d`` to allow for in-function masking
   of near-zero results to be set to 0.0.
+* Fixed malformed logging outputs which could be seen during long running
+  ``rasterize`` calls.
 
 1.9.2 (2020-02-06)
 ------------------

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -3255,9 +3255,7 @@ def _make_logger_callback(message):
                 if p_progress_arg:
                     LOGGER.info(message, df_complete * 100, p_progress_arg[0])
                 else:
-                    LOGGER.info(
-                        'p_progress_arg is None df_complete: %s, message: %s',
-                        df_complete, message)
+                    LOGGER.info(message, df_complete * 100, '')
                 logger_callback.last_time = current_time
                 logger_callback.total_time += current_time
         except AttributeError:


### PR DESCRIPTION
This was an easy one, looks like I had a special case in `_make_logger_callback` if the `p_progress_arg` parameter was None. I think I'd interpreted that as a bug back in the day and hastily put a log message in there. I've since replaced it with a log that will look like this on a long rasterize (I ran it locally):

```
2020-05-06 00:14:44,633 (7266) INFO pygeoprocessing.geoprocessing [logger_callback:3258] RasterizeLayer 2.4% complete
2020-05-06 00:14:53,895 (16529) INFO pygeoprocessing.geoprocessing [logger_callback:3258] RasterizeLayer 3.6% complete
2020-05-06 00:15:03,073 (25707) INFO pygeoprocessing.geoprocessing [logger_callback:3258] RasterizeLayer 4.8% complete
2020-05-06 00:15:11,705 (34339) INFO pygeoprocessing.geoprocessing [logger_callback:3258] RasterizeLayer 6.0% complete
2020-05-06 00:15:19,903 (42537) INFO pygeoprocessing.geoprocessing [logger_callback:3258] RasterizeLayer 7.2% complete
2020-05-06 00:15:28,060 (50694) INFO pygeoprocessing.geoprocessing [logger_callback:3258] RasterizeLayer 8.5% complete
2020-05-06 00:15:38,641 (61275) INFO pygeoprocessing.geoprocessing [logger_callback:3258] RasterizeLayer 9.7% complete
2020-05-06 00:15:47,133 (69767) INFO pygeoprocessing.geoprocessing [logger_callback:3258] RasterizeLayer 10.9% complete
2020-05-06 00:15:55,927 (78560) INFO pygeoprocessing.geoprocessing [logger_callback:3258] RasterizeLayer 12.1% complete
```

I didn't update any tests for this because of the complexity that I can go into if you need.

Closes issue #37 