### PR TITLE
fixes #46, adding a fix to is_close vs == for root height, an issue w…

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,10 +17,12 @@ Unreleased Changes
   of near-zero results to be set to 0.0.
 * Fixed a malformed ``ValueError`` message when a corrupt raster was
   encountered in ``raster_calculator``.
-* Fixes an uncessary calculation that pre-fills slope raster GeoTIFFs with
+* Fixes an unnecessary calculation that pre-fills slope raster GeoTIFFs with
   nodata values.
 * Added a check to ``convolve_2d`` to verify that raster path/band tuples were
-  passed where expected and raise a useful Exception  if not.
+  passed where expected and raise a useful Exception if not.
+* Fixed an issue in ``flow_dir_mfd`` that would cause invalid flow directions
+  on DEMs that had very small numerical delta heights.
 
 1.9.2 (2020-02-06)
 ------------------

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -479,6 +479,11 @@ cdef class _ManagedRaster:
                     time.sleep(0.2)
                     continue
                 break
+            if max_retries == 0:
+                raise ValueError(
+                    f'unable to open {self.raster_path} in '
+                    'ManagedRaster.flush')
+            raster_band = raster.GetRasterBand(self.band_id)
 
         block_array = numpy.empty(
             (self.block_ysize, self.block_xsize), dtype=numpy.double)

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -468,9 +468,17 @@ cdef class _ManagedRaster:
 
         raster_band = None
         if self.write_mode:
-            raster = gdal.OpenEx(
-                self.raster_path, gdal.GA_Update | gdal.OF_RASTER)
-            raster_band = raster.GetRasterBand(self.band_id)
+            max_retries = 5
+            while max_retries > 0:
+                raster = gdal.OpenEx(
+                    self.raster_path, gdal.GA_Update | gdal.OF_RASTER)
+                if raster is None:
+                    max_retries -= 1
+                    LOGGER.error(
+                        f'unable to open {self.raster_path}, retrying...')
+                    time.sleep(0.2)
+                    continue
+                break
 
         block_array = numpy.empty(
             (self.block_ysize, self.block_xsize), dtype=numpy.double)
@@ -1946,8 +1954,8 @@ def flow_dir_mfd(
                         n_drain_distance = drain_distance + (
                             SQRT2 if i_n & 1 else 1.0)
 
-                        if is_close(dem_managed_raster.get(
-                                xi_n, yi_n), root_height) and (
+                        if (<double>(dem_managed_raster.get(
+                                xi_n, yi_n)) == root_height) and (
                                 plateau_distance_managed_raster.get(
                                     xi_n, yi_n) > n_drain_distance):
                             # neighbor is at same level and has longer drain

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -6,11 +6,8 @@ import os
 
 from osgeo import gdal
 from osgeo import osr
-from osgeo import ogr
 import numpy
 import numpy.testing
-import shapely.geometry
-import shapely.wkb
 
 import logging
 
@@ -1181,7 +1178,7 @@ class TestRouting(unittest.TestCase):
         dem_raster = None
 
         target_flow_dir_path = os.path.join(
-            workspace_dir, 'flow_dir.tif')
+            self.workspace_dir, 'flow_dir.tif')
 
         pygeoprocessing.routing.flow_dir_mfd(
             (dem_path, 1), target_flow_dir_path,

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1153,12 +1153,11 @@ class TestRouting(unittest.TestCase):
         import pygeoprocessing.routing
 
         driver = gdal.GetDriverByName('GTiff')
-        workspace_dir = 'flow_dir_debug'
         try:
-            os.makedirs(workspace_dir)
+            os.makedirs(self.workspace_dir)
         except OSError:
             pass
-        dem_path = os.path.join(workspace_dir, 'dem.tif')
+        dem_path = os.path.join(self.workspace_dir, 'dem.tif')
         # this makes a flat raster
         n = 100
         dem_array = numpy.zeros((n, n))

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1147,3 +1147,52 @@ class TestRouting(unittest.TestCase):
 
         numpy.testing.assert_almost_equal(
             distance_to_channel_d8_array, zero_array)
+
+    def test_flow_dir_mfd_plateau(self):
+        """PGP.routing: MFD on a plateau."""
+        import pygeoprocessing.routing
+
+        driver = gdal.GetDriverByName('GTiff')
+        workspace_dir = 'flow_dir_debug'
+        try:
+            os.makedirs(workspace_dir)
+        except OSError:
+            pass
+        dem_path = os.path.join(workspace_dir, 'dem.tif')
+        # this makes a flat raster
+        n = 100
+        dem_array = numpy.zeros((n, n))
+        dem_nodata = -1
+        dem_array[2, :] = 1e-12
+        dem_array[n//2, :] = 1e-12
+        dem_array[3*n//4, :] = 1e-12
+        dem_raster = driver.Create(
+            dem_path, dem_array.shape[1], dem_array.shape[0], 1,
+            gdal.GDT_Float32)
+        wgs84 = osr.SpatialReference()
+        wgs84.ImportFromEPSG(4326)
+        dem_raster.SetGeoTransform([1, 1.0, 0.0, 1, 0.0, -1.0])
+        dem_raster.SetProjection(wgs84.ExportToWkt())
+
+        dem_band = dem_raster.GetRasterBand(1)
+        dem_band.WriteArray(dem_array)
+        dem_band.SetNoDataValue(dem_nodata)
+        dem_band.FlushCache()
+        dem_band = None
+        dem_raster = None
+
+        target_flow_dir_path = os.path.join(
+            workspace_dir, 'flow_dir.tif')
+
+        pygeoprocessing.routing.flow_dir_mfd(
+            (dem_path, 1), target_flow_dir_path,
+            working_dir=self.workspace_dir)
+
+        flow_dir_raster = gdal.OpenEx(target_flow_dir_path, gdal.OF_RASTER)
+        flow_dir_array = flow_dir_raster.ReadAsArray()
+        flow_dir_raster = None
+        flow_dir_nodata = pygeoprocessing.get_raster_info(
+            target_flow_dir_path)['nodata'][0]
+        self.assertTrue(not numpy.isclose(
+            flow_dir_array[1:-1, 1: -1], flow_dir_nodata).any(),
+            'all flow directions should be defined')


### PR DESCRIPTION
Hi @phargogh and @dcdenu4, requesting both of your reviews because this addresses the same bug you both found in different ways. @phargogh, this fixes Chris's weird DEM route and @dcdenu4, this fixes that user's forum question where there was an out of memory error during routing.

The bug was in flow_dir_mfd in the section where the algorithm walks through a plateau to determine where it can drain. It does this by comparing its current height with its neighbors and seeing if the neighbor has a shorter route. Except i was comparing heights with an is_close rather than == as we have been used to for comparing nodata values. Except in this case both of these users' data had VERY small deltas between some of the dem heights, such as 12.2347328328 and 12.2347329383. is_close returned true for both of these values. So now I ensure both values from the DEM are cast to 64 bit floating point values then compared. If there's a numerical roundoff there it will be the same numerical roundoff and results will be correct when checking for equality.

Also during testing I was able to catch and re-create a flaky bug where a ManagedRaster will flush the cache but sometimes be unable to open the raster to do so. This can occur as a race condition of hopping around a big raster and GDAL hasn't necessarily cleared out its cache for the raster yet. I explicitly test for this now and wait 0.2 seconds up to 5 times to retry.

I've included an okayish test that I feel covers this, though it is not large enough to cause a memory error like the user @dcdenu4 worked with. I have, however, directly routed that user's data so I can informally verify it works in this PR.

closes #46