### PR TITLE
Merge changes from master into release/2.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,8 @@ Unreleased Changes
   might be included with the source distribution.
 * Added ``set_tol_to_zero`` to ``convolve_2d`` to allow for in-function masking
   of near-zero results to be set to 0.0.
+* Fixed malformed logging outputs which could be seen during long running
+  ``rasterize`` calls.
 
 1.9.2 (2020-02-06)
 ------------------

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -3255,9 +3255,7 @@ def _make_logger_callback(message):
                 if p_progress_arg:
                     LOGGER.info(message, df_complete * 100, p_progress_arg[0])
                 else:
-                    LOGGER.info(
-                        'p_progress_arg is None df_complete: %s, message: %s',
-                        df_complete, message)
+                    LOGGER.info(message, df_complete * 100, '')
                 logger_callback.last_time = current_time
                 logger_callback.total_time += current_time
         except AttributeError:


### PR DESCRIPTION
The PR at https://github.com/natcap/pygeoprocessing/pull/82 had a merge conflict in HISTORY.  This PR resolves the conflict and will allow the latest changes to be included in release/2.0.