### PR TITLE
Bugfix/geoprocessing 87 nodata holes in convolve 2d

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -52,6 +52,9 @@ Unreleased Changes
     ``Shapely`` geometry.
 * Fixed an issue in ``flow_dir_mfd`` that would cause invalid flow directions
   on DEMs that had very small numerical delta heights.
+* Fixes an issue in ``convolve_2d`` that would occasionally cause undefined
+  numerical noise in regions where the signal was nodata but ``mask_nodata``
+  was set to ``False``.
 
 1.9.2 (2020-02-06)
 ------------------


### PR DESCRIPTION
This PR fixes an issue where NaN holes would accumulate when `convolve_2d` was invoked with `ignore_nodata_and_edges=True` but `mask_nodata=False`. Rather than set the non-maksed nodata values to 0 they were treated as an empty value. This PR fixes that and has a test to cover that case.

Closes #87 