### PR TITLE
Feature/40 ws delineation logging

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,18 @@
 Release History
 ===============
 
+Unreleased Changes
+------------------
+* Correcting the docstring for ``pygeoprocessing.numpy_array_to_raster`` to
+  specify that the ``pixel_size`` parameter must be a tuple or list, not an
+  int.
+* ``pygeoprocessing.routing.delineate_watersheds_d8`` now has an optional
+  parameter ``write_diagnostic_vector``.  When ``True``, this parameter will
+  cause a new vector per outflow feature to be created in the ``working_dir``.
+  This parameter defaults to ``False``.  This is a change from prior behavior,
+  when the diagnostic vectors were always created, which could occupy a lot of
+  computational time under large outflow geometries.
+
 2.0.0 (05-19-2020)
 ------------------
 * Adding Python 3.8 support and dropping Python 3.6 support.

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -3613,7 +3613,7 @@ def numpy_array_to_raster(
     Args:
         base_array (numpy.array): a 2d numpy array.
         target_nodata (numeric): nodata value of target array, can be None.
-        pixel_size (int): square dimensions of pixel.
+        pixel_size (tuple): square dimensions (in ``(x, y)``) of pixel.
         origin (tuple/list): x/y coordinate of the raster origin.
         projection_wkt (str): target projection in wkt.
         target_path (str): path to raster to create that will be of the

--- a/src/pygeoprocessing/routing/watershed.pyx
+++ b/src/pygeoprocessing/routing/watershed.pyx
@@ -483,9 +483,11 @@ cdef cset[CoordinatePair] _c_split_geometry_into_seeds(
     memory_driver = gdal.GetDriverByName('Memory')
     new_vector = memory_driver.Create('mem', 0, 0, 0, gdal.GDT_Unknown)
     new_layer = new_vector.CreateLayer('user_geometry', flow_dir_srs, ogr.wkbUnknown)
+    new_layer.StartTransaction()
     new_feature = ogr.Feature(new_layer.GetLayerDefn())
     new_feature.SetGeometry(ogr.CreateGeometryFromWkb(source_geom_wkb))
     new_layer.CreateFeature(new_feature)
+    new_layer.CommitTransaction()
 
     local_origin_x = max(minx_aligned, x_origin)
     local_origin_y = min(maxy_aligned, y_origin)
@@ -518,9 +520,11 @@ cdef cset[CoordinatePair] _c_split_geometry_into_seeds(
             'seeds', flow_dir_srs, ogr.wkbPoint)
         user_geometry_layer = diagnostic_vector.CreateLayer(
             'user_geometry', flow_dir_srs, ogr.wkbUnknown)
+        user_geometry_layer.StartTransaction()
         user_feature = ogr.Feature(user_geometry_layer.GetLayerDefn())
         user_feature.SetGeometry(ogr.CreateGeometryFromWkb(source_geom_wkb))
         user_geometry_layer.CreateFeature(user_feature)
+        user_geometry_layer.CommitTransaction()
 
     cdef int row, col
     cdef int global_row, global_col
@@ -548,6 +552,7 @@ cdef cset[CoordinatePair] _c_split_geometry_into_seeds(
                 global_col = seed_raster_origin_col + block_xoff + col
 
                 if write_diagnostic_vector == 1:
+                    diagnostic_layer.StartTransaction()
                     new_feature = ogr.Feature(diagnostic_layer.GetLayerDefn())
                     new_feature.SetGeometry(ogr.CreateGeometryFromWkb(
                         shapely.geometry.Point(
@@ -556,6 +561,7 @@ cdef cset[CoordinatePair] _c_split_geometry_into_seeds(
                             y_origin + ((global_row*y_pixelwidth) +
                                         (y_pixelwidth / 2.))).wkb))
                     diagnostic_layer.CreateFeature(new_feature)
+                    diagnostic_layer.CommitTransaction()
 
                 seed_set.insert(CoordinatePair(global_col, global_row))
 

--- a/tests/test_watershed_delineation.py
+++ b/tests/test_watershed_delineation.py
@@ -45,19 +45,13 @@ class WatershedDelineationTests(unittest.TestCase):
         srs_wkt = srs.ExportToWkt()
 
         flow_dir_path = os.path.join(self.workspace_dir, 'flow_dir.tif')
-        driver = gdal.GetDriverByName('GTiff')
-        flow_dir_raster = driver.Create(
-            flow_dir_path, flow_dir_array.shape[1], flow_dir_array.shape[0],
-            1, gdal.GDT_Byte, options=(
-                'TILED=YES', 'BIGTIFF=YES', 'COMPRESS=LZW',
-                'BLOCKXSIZE=256', 'BLOCKYSIZE=256'))
-        flow_dir_raster.SetProjection(srs_wkt)
-        flow_dir_band = flow_dir_raster.GetRasterBand(1)
-        flow_dir_band.WriteArray(flow_dir_array)
-        flow_dir_band.SetNoDataValue(255)
-        flow_dir_geotransform = [2, 2, 0, -2, 0, -2]
-        flow_dir_raster.SetGeoTransform(flow_dir_geotransform)
-        flow_dir_raster = None
+        pygeoprocessing.numpy_array_to_raster(
+            base_array=flow_dir_array,
+            target_nodata=255,
+            pixel_size=(2, -2),
+            origin=(2, -2),
+            projection_wkt=srs_wkt,
+            target_path=flow_dir_path)
 
         # These geometries test:
         #  * Delineation works with varying geometry types
@@ -85,7 +79,7 @@ class WatershedDelineationTests(unittest.TestCase):
                 {'polygon_id': 3, 'field_string': 'hello bar', 'other': 3.333},
                 {'polygon_id': 4, 'field_string': 'hello baz', 'other': 4.444}
             ],
-            ogr_geom_type=ogr.wkbGeometryCollection)
+            ogr_geom_type=ogr.wkbUnknown)
 
         target_watersheds_path = os.path.join(
             self.workspace_dir, 'watersheds.gpkg')

--- a/tests/test_watershed_delineation.py
+++ b/tests/test_watershed_delineation.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import tempfile
 import unittest
+import glob
 
 from osgeo import gdal
 from osgeo import ogr
@@ -24,6 +25,77 @@ class WatershedDelineationTests(unittest.TestCase):
     def tearDown(self):
         """Delete workspace dir."""
         shutil.rmtree(self.workspace_dir)
+
+    def test_watersheds_diagnostic_vector(self):
+        """PGP watersheds: test diagnostic vector."""
+        flow_dir_array = numpy.array([
+            [6, 6, 6, 6, 6, 6, 6, 6, 6, 6],
+            [6, 6, 6, 6, 6, 6, 6, 6, 6, 6],
+            [6, 6, 6, 6, 6, 6, 6, 6, 6, 6],
+            [6, 6, 6, 6, 6, 6, 6, 6, 6, 255],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [2, 2, 2, 2, 2, 2, 2, 2, 2, 255],
+            [2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
+            [2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
+            [2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
+            [2, 2, 2, 2, 2, 2, 2, 2, 2, 2]],
+            dtype=numpy.int8)
+
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(32731)  # WGS84 / UTM zone 31s
+        srs_wkt = srs.ExportToWkt()
+
+        flow_dir_path = os.path.join(self.workspace_dir, 'flow_dir.tif')
+        pygeoprocessing.numpy_array_to_raster(
+            base_array=flow_dir_array,
+            target_nodata=255,
+            pixel_size=(2, -2),
+            origin=(2, -2),
+            projection_wkt=srs_wkt,
+            target_path=flow_dir_path)
+
+        # These geometries test:
+        #  * Delineation works with varying geometry types
+        #  * That we exclude seed pixels that are over nodata
+        #  * That we exclude seed pixels off the bounds of the raster
+        horizontal_line = shapely.geometry.LineString([(19, -11), (25, -11)])
+        vertical_line = shapely.geometry.LineString([(21, -9), (21, -13)])
+        square = shapely.geometry.box(17, -13, 21, -9)
+        point = shapely.geometry.Point(21, -11)
+
+        outflow_vector_path = os.path.join(self.workspace_dir, 'outflow.gpkg')
+        pygeoprocessing.shapely_geometry_to_vector(
+            [horizontal_line, vertical_line, square, point],
+            outflow_vector_path, srs_wkt,
+            'GPKG',
+            {
+                'polygon_id': ogr.OFTInteger,
+                'field_string': ogr.OFTString,
+                'other': ogr.OFTReal
+            },
+            [
+                {'polygon_id': 1, 'field_string': 'hello world',
+                 'other': 1.111},
+                {'polygon_id': 2, 'field_string': 'hello foo', 'other': 2.222},
+                {'polygon_id': 3, 'field_string': 'hello bar', 'other': 3.333},
+                {'polygon_id': 4, 'field_string': 'hello baz', 'other': 4.444}
+            ],
+            ogr_geom_type=ogr.wkbUnknown)
+
+        target_watersheds_path = os.path.join(
+            self.workspace_dir, 'watersheds.gpkg')
+
+        pygeoprocessing.routing.delineate_watersheds_d8(
+            (flow_dir_path, 1), outflow_vector_path, target_watersheds_path,
+            write_diagnostic_vector=True, working_dir=self.workspace_dir,
+            remove_temp_files=False)
+
+        # I'm deliberately only testing that the diagnostic files exist, not
+        # the contents.  The diagnostic files should be for debugging only,
+        # so I just want to make sure that they're created.
+        num_diagnostic_files = len(
+            glob.glob(os.path.join(self.workspace_dir, '**/*_seeds.gpkg')))
+        self.assertEqual(num_diagnostic_files, 3)  # 3 features valid
 
     def test_watersheds_trivial(self):
         """PGP watersheds: test trivial delineation."""


### PR DESCRIPTION
This PR fixes #40 not by adding logging as the issue suggests, but by instead disabling by default the case where logging feels necessary (when creating diagnostic vectors) and adding a flag to enable the diagnostic vector itself when needed.

On large input geometries, this change yields a significant speedup since we're reducing the python overhead in creating lots of little polygons in each diagnostic vector.