### PR TITLE
Explicitly pulling tags as well.  RE:#45

### DIFF
--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -27,6 +27,9 @@ jobs:
                   # Fetch all history so that setuptools_scm can build the correct version string.
                   fetch-depth: 0
 
+            - name: Fetch git tags
+              run: git fetch origin +refs/tags/*:refs/tags/*
+
             - name: Set up python ${{ matrix.python-version }} ${{ matrix.python-arch }}
               uses: actions/setup-python@v1
               with:
@@ -52,6 +55,9 @@ jobs:
               with:
                   # Fetch all history so that setuptools_scm can build the correct version string.
                   fetch-depth: 0
+
+            - name: Fetch git tags
+              run: git fetch origin +refs/tags/*:refs/tags/*
 
             - name: Set up python
               uses: actions/setup-python@v1


### PR DESCRIPTION
This fixes #45 by simply adding a step to pull tags when we build the python distributions.

This works: take a look at [this build](https://github.com/natcap/pygeoprocessing/pull/101/checks?check_run_id=743986004), and the wheel `dist/pygeoprocessing-2.0.0.post9+g6e6560b-cp38-cp38-macosx_10_14_x86_64.whl` is constructed, which has the correct version string in the filename.