### PR TITLE
Adding custom exception for reclassification error

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,15 @@ Release History
 
 Unreleased Changes
 ------------------
+* Adding custom exception ``ReclassificationMissingValuesError`` that can 
+  occur when mapping raster values to dictionary keys, where a raster value 
+  is not represented in the dictionary as a key. The custom exception takes 
+  3 arguments that are set as attributes:
+  * ``msg`` - a string for the error message
+  * ``missing_values`` - a list of raster values not found in the dictionary
+  * ``value_map`` - the dictionary the raster values were attempted to map to
+  This error is now raised in ``reclassify_raster`` and can be caught 
+  to better debug the mismatch when using a table to reclassify a raster. 
 * Correcting the docstring for ``pygeoprocessing.numpy_array_to_raster`` to
   specify that the ``pixel_size`` parameter must be a tuple or list, not an
   int.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,15 +3,13 @@ Release History
 
 Unreleased Changes
 ------------------
-* Adding custom exception ``ReclassificationMissingValuesError`` that can 
-  occur when mapping raster values to dictionary keys, where a raster value 
-  is not represented in the dictionary as a key. The custom exception takes 
-  3 arguments that are set as attributes:
-  * ``msg`` - a string for the error message
-  * ``missing_values`` - a list of raster values not found in the dictionary
-  * ``value_map`` - the dictionary the raster values were attempted to map to
-  This error is now raised in ``reclassify_raster`` and can be caught 
-  to better debug the mismatch when using a table to reclassify a raster. 
+* Added a custom exception class ``ReclassificationMissingValuesError`` to 
+  ``pygeoprocessing``. ``pygeoprocessing.reclassify_raster`` raises this
+  exception instead of ``ValueError`` when a raster pixel value is not
+  represented in ``value_map``. This custom exception provides a list of 
+  missing raster pixel values in a ``missing_values`` attribute that allows
+  the caller access to the pixel values that are missing through a Python type
+  rather than indirectly through an error message.
 * Correcting the docstring for ``pygeoprocessing.numpy_array_to_raster`` to
   specify that the ``pixel_size`` parameter must be a tuple or list, not an
   int.

--- a/src/pygeoprocessing/__init__.py
+++ b/src/pygeoprocessing/__init__.py
@@ -13,7 +13,8 @@ from .geoprocessing_core import raster_band_percentile
 import pkg_resources
 __version__ = pkg_resources.get_distribution(__name__).version
 
-__all__ = ('calculate_slope', 'raster_band_percentile')
+__all__ = ('calculate_slope', 'raster_band_percentile', 
+           'ReclassificationMissingValuesError')
 for attrname in dir(geoprocessing):
     attribute = getattr(geoprocessing, attrname)
     if isinstance(attribute, types.FunctionType):

--- a/src/pygeoprocessing/__init__.py
+++ b/src/pygeoprocessing/__init__.py
@@ -7,6 +7,7 @@ import sys
 import types
 
 from . import geoprocessing
+from .geoprocessing import ReclassificationMissingValuesError
 from .geoprocessing_core import calculate_slope
 from .geoprocessing_core import raster_band_percentile
 import pkg_resources

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -36,15 +36,12 @@ class ReclassificationMissingValuesError(Exception):
         msg (str) - error message
         missing_values (list) - a list of the missing values from the raster
             that are not keys in the dictionary
-        value_map (dict) - the dictionary used to map raster values
-
     """
 
-    def __init__(self, msg, missing_values, value_map):
+    def __init__(self, msg, missing_values):
         self.msg = msg
         self.missing_values = missing_values
-        self.value_map = value_map
-        super().__init__(msg, missing_values, value_map)
+        super().__init__(msg, missing_values)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -1737,7 +1734,7 @@ def reclassify_raster(
     Raises:
         ReclassificationMissingValuesError if ``values_required`` is ``True``
         and a pixel value from ``base_raster_path_band`` is not a key in
-        ``attr_dict``.
+        ``value_map``.
 
     """
     if len(value_map) == 0:
@@ -1767,7 +1764,7 @@ def reclassify_raster(
                     f'The following {missing_values.size} raster values'
                     f' {missing_values} from "{base_raster_path_band[0]}"'
                     ' do not have corresponding entries in the ``value_map``:'
-                    f' {value_map}.', missing_values, value_map)
+                    f' {value_map}.', missing_values)
         index = numpy.digitize(original_values.ravel(), keys, right=True)
         return values[index].reshape(original_values.shape)
 

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -33,6 +33,7 @@ class ReclassificationMissingValuesError(Exception):
     """Raised when a raster value is not a valid key to a dictionary.
 
     Attributes:
+        msg (str) - error message
         missing_values (list) - a list of the missing values from the raster
             that are not keys in the dictionary
         value_map (dict) - the dictionary used to map raster values
@@ -1734,8 +1735,9 @@ def reclassify_raster(
         None
 
     Raises:
-        ValueError if ``values_required`` is ``True`` and a pixel value from
-           ``base_raster_path_band`` is not a key in ``attr_dict``.
+        ReclassificationMissingValuesError if ``values_required`` is ``True``
+        and a pixel value from ``base_raster_path_band`` is not a key in
+        ``attr_dict``.
 
     """
     if len(value_map) == 0:

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -98,8 +98,6 @@ class PyGeoprocessing10(unittest.TestCase):
 
     def test_reclassify_raster_missing_pixel_value(self):
         """PGP.geoprocessing: test reclassify raster with missing value."""
-        reclass_error = pygeoprocessing.ReclassificationMissingValuesError
-
         n_pixels = 9
         pixel_matrix = numpy.ones((n_pixels, n_pixels), numpy.float32)
         test_value = 0.5
@@ -115,11 +113,12 @@ class PyGeoprocessing10(unittest.TestCase):
             test_value: 100,
         }
         target_nodata = -1
-        with self.assertRaises(reclass_error) as cm:
+        with self.assertRaises(
+                pygeoprocessing.ReclassificationMissingValuesError) as cm:
             pygeoprocessing.reclassify_raster(
                 (raster_path, 1), value_map, target_path, gdal.GDT_Float32,
                 target_nodata, values_required=True)
-        expected_message = ('The following 1 raster values [-0.5]')
+        expected_message = 'The following 1 raster values [-0.5]'
         actual_message = str(cm.exception)
         self.assertTrue(expected_message in actual_message, actual_message)
 

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -17,6 +17,7 @@ import shapely.wkt
 
 import pygeoprocessing
 import pygeoprocessing.symbolic
+
 from pygeoprocessing.geoprocessing_core import \
     DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS
 
@@ -98,6 +99,8 @@ class PyGeoprocessing10(unittest.TestCase):
 
     def test_reclassify_raster_missing_pixel_value(self):
         """PGP.geoprocessing: test reclassify raster with missing value."""
+        reclass_error = pygeoprocessing.ReclassificationMissingValuesError
+
         n_pixels = 9
         pixel_matrix = numpy.ones((n_pixels, n_pixels), numpy.float32)
         test_value = 0.5
@@ -113,13 +116,11 @@ class PyGeoprocessing10(unittest.TestCase):
             test_value: 100,
         }
         target_nodata = -1
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(reclass_error) as cm:
             pygeoprocessing.reclassify_raster(
                 (raster_path, 1), value_map, target_path, gdal.GDT_Float32,
                 target_nodata, values_required=True)
-        expected_message = (
-            'The following 1 raster values [-0.5] from "%s" do not have ' %
-            (raster_path,))
+        expected_message = ('The following 1 raster values [-0.5]')
         actual_message = str(cm.exception)
         self.assertTrue(expected_message in actual_message, actual_message)
 

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -17,7 +17,6 @@ import shapely.wkt
 
 import pygeoprocessing
 import pygeoprocessing.symbolic
-
 from pygeoprocessing.geoprocessing_core import \
     DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS
 

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -82,7 +82,8 @@ class PyGeoprocessing10(unittest.TestCase):
                 func = getattr(pygeoprocessing, attrname)
                 self.assertTrue(
                     isinstance(func, (
-                        types.FunctionType, types.BuiltinFunctionType)) or
+                        types.FunctionType, types.BuiltinFunctionType,
+                        types.MethodType)) or
                     inspect.isroutine(func))
             except AttributeError:
                 self.fail(('Function %s is in pygeoprocessing.__all__ but '

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -82,8 +82,8 @@ class PyGeoprocessing10(unittest.TestCase):
                 func = getattr(pygeoprocessing, attrname)
                 self.assertTrue(
                     isinstance(func, (
-                        types.FunctionType, types.BuiltinFunctionType,
-                        types.MethodType)) or
+                        types.FunctionType, types.BuiltinFunctionType)) or
+                    issubclass(func, Exception) or
                     inspect.isroutine(func))
             except AttributeError:
                 self.fail(('Function %s is in pygeoprocessing.__all__ but '


### PR DESCRIPTION
Adding a custom exception to `pygeoprocessing/geoprocessing.py` called `ReclassificationMissingValuesError` that takes a _message_, _missing values_, and _value map_. These are set as attributes that can then be accessed via InVEST for example.

Added the importing of this custom class to `__init__.py` so it is available via `pygeoprocessing.ReclassificationMissingValuesError`.

Closes #105 