### PR TITLE
fixes #109 guarding against "ignore edge/nodata" but "don't mask nodata"

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,10 +3,14 @@ Release History
 
 Unreleased Changes
 ------------------
-* Added a custom exception class ``ReclassificationMissingValuesError`` to 
+* Modified ``pygeoprocessing.convolve_2d`` to guard against nonsensical queries
+  to both ``ignore_nodata_and_edges=True`` but also ``mask_nodata=False``.
+  A query of this combination now raises a ``ValueError`` to guard against
+  programmer error.
+* Added a custom exception class ``ReclassificationMissingValuesError`` to
   ``pygeoprocessing``. ``pygeoprocessing.reclassify_raster`` raises this
   exception instead of ``ValueError`` when a raster pixel value is not
-  represented in ``value_map``. This custom exception provides a list of 
+  represented in ``value_map``. This custom exception provides a list of
   missing raster pixel values in a ``missing_values`` attribute that allows
   the caller access to the pixel values that are missing through a Python type
   rather than indirectly through an error message.
@@ -17,8 +21,8 @@ Unreleased Changes
   parameter ``write_diagnostic_vector``.  When ``True``, this parameter will
   cause a new vector per outflow feature to be created in the ``working_dir``.
   This parameter defaults to ``False``.  This is a change from prior behavior,
-  when the diagnostic vectors were always created, which could occupy a lot of
-  computational time under large outflow geometries.
+  when the diagnostic vectors were always created, which could occupy
+  significant computational time under large outflow geometries.
 
 2.0.0 (05-19-2020)
 ------------------

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2384,7 +2384,11 @@ def convolve_2d(
         normalize_kernel (boolean): If true, the result is divided by the
             sum of the kernel.
         mask_nodata (boolean): If true, ``target_path`` raster's output is
-            nodata where ``signal_path_band``'s pixels were nodata.
+            nodata where ``signal_path_band``'s pixels were nodata. Note that
+            setting ``ignore_nodata_and_edges`` to ``True`` while setting
+            ``mask_nodata`` to False would be a nonsensical result and would
+            result in exposing the numerical noise where the nodata values were
+            ignored. An exception is thrown in this case.
         target_datatype (GDAL type): a GDAL raster type to set the output
             raster type to, as well as the type to calculate the convolution
             in.  Defaults to GDT_Float64.  Note signed byte is not
@@ -2414,12 +2418,22 @@ def convolve_2d(
 
     Returns:
         None
+
+    Raises:
+        ValueError if ``ignore_nodata_and_edges`` is ``True`` and
+            ``mask_nodata`` is ``False``
+
     """
     if target_datatype is not gdal.GDT_Float64 and target_nodata is None:
         raise ValueError(
             "`target_datatype` is set, but `target_nodata` is None. "
             "`target_nodata` must be set if `target_datatype` is not "
             "`gdal.GDT_Float64`.  `target_nodata` is set to None.")
+
+    if ignore_nodata_and_edges and not mask_nodata:
+        raise ValueError(
+            f'ignore_nodata_and_edges is True while mask_nodata is False -- '
+            f'this would yield a nonsensical result.')
 
     bad_raster_path_list = []
     for raster_id, raster_path_band in [

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -4134,8 +4134,8 @@ class PyGeoprocessing10(unittest.TestCase):
         array = pygeoprocessing.raster_to_numpy_array(target_raster_path)
         numpy.testing.assert_array_equal(pixel_a_matrix, array)
 
-    def test_convolve_2d_bad_path_bands(self):
-        """PGP.geoprocessing: test convolve 2d bad raster path bands."""
+    def test_convolve_2d_bad_input_data(self):
+        """PGP.geoprocessing: test convolve 2d for programmer error."""
         signal_path = os.path.join(self.workspace_dir, 'signal.tif')
         kernel_path = os.path.join(self.workspace_dir, 'kernel.tif')
         target_path = os.path.join(self.workspace_dir, 'target.tif')
@@ -4147,6 +4147,14 @@ class PyGeoprocessing10(unittest.TestCase):
         # we expect an error about both signal and kernel
         self.assertTrue('signal' in actual_message)
         self.assertTrue('kernel' in actual_message)
+
+        with self.assertRaises(ValueError) as cm:
+            pygeoprocessing.convolve_2d(
+                (signal_path, 1), (kernel_path, 1), target_path,
+                ignore_nodata_and_edges=True, mask_nodata=False)
+        actual_message = str(cm.exception)
+        # we expect an error about ignoring nodata in message
+        self.assertTrue('ignore_nodata_and_edges' in actual_message)
 
     def test_convolve_2d_nodata(self):
         """PGP.geoprocessing: test convolve 2d (single thread)."""

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2476,7 +2476,7 @@ class PyGeoprocessing10(unittest.TestCase):
         target_path = os.path.join(self.workspace_dir, 'target.tif')
         pygeoprocessing.convolve_2d(
             (signal_path, 1), (kernel_path, 1), target_path,
-            mask_nodata=False, ignore_nodata_and_edges=True,
+            mask_nodata=True, ignore_nodata_and_edges=True,
             normalize_kernel=True)
         target_array = pygeoprocessing.raster_to_numpy_array(target_path)
         expected_result = test_value * n_pixels ** 2
@@ -4154,8 +4154,8 @@ class PyGeoprocessing10(unittest.TestCase):
         signal_array = numpy.empty((n_pixels//10, n_pixels//10), numpy.float32)
         base_nodata = -1
         signal_array[:] = base_nodata
-        signal_array[n_pixels//20, n_pixels//20] = 0
         signal_array[0, 0] = 1
+        signal_array[-1, -1] = 0
         signal_path = os.path.join(self.workspace_dir, 'signal.tif')
         _array_to_raster(signal_array, base_nodata, signal_path)
         kernel_path = os.path.join(self.workspace_dir, 'kernel.tif')
@@ -4164,9 +4164,13 @@ class PyGeoprocessing10(unittest.TestCase):
         target_path = os.path.join(self.workspace_dir, 'target.tif')
         pygeoprocessing.convolve_2d(
             (signal_path, 1), (kernel_path, 1), target_path,
-            n_threads=1, ignore_nodata_and_edges=True, mask_nodata=False)
+            n_threads=1, ignore_nodata_and_edges=False, mask_nodata=True)
         target_array = pygeoprocessing.raster_to_numpy_array(target_path)
+        target_nodata = pygeoprocessing.get_raster_info(
+            target_path)['nodata'][0]
 
         expected_output = numpy.empty(signal_array.shape, numpy.float32)
-        expected_output[:] = n_pixels**2 // 2
+        expected_output[:] = target_nodata
+        expected_output[0, 0] = 1
+        expected_output[-1, -1] = 1
         numpy.testing.assert_allclose(target_array, expected_output)


### PR DESCRIPTION
Addresses a nonsensical combination of parameters for `convolve_2d` where `ignore_nodata_and_edges=True` and `mask_nodata=False`. Rather than allow this combination and return numerical noise, the function now raises a `ValueError`. Updated docstring, tests, and history to reflect this change.