### PR TITLE
fixes #102, better logging message and update to history

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -23,6 +23,9 @@ Unreleased Changes
   This parameter defaults to ``False``.  This is a change from prior behavior,
   when the diagnostic vectors were always created, which could occupy
   significant computational time under large outflow geometries.
+* Modified logging message for ``pygeoprocessing.new_raster_from_base`` when
+  filling a raster such that an informative error message is printed with
+  context as to the function, file, status, and value being filled.
 
 2.0.0 (05-19-2020)
 ------------------

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -881,8 +881,9 @@ def new_raster_from_base(
 
                 last_time = _invoke_timed_callback(
                     last_time, lambda: LOGGER.info(
-                        '%.1f%% complete',
-                        float(pixels_processed) / n_pixels * 100.0),
+                        f'filling new raster {target_path} with {fill_value} '
+                        f'-- {float(pixels_processed)/n_pixels*100.0:.2f}% '
+                        f'complete'),
                     _LOGGING_PERIOD)
             target_band = None
     target_band = None


### PR DESCRIPTION
This PR fixes an issue that would report `"pygeoprocessing.geoprocessing [<lambda>:911]  3.21%% complete"` messages when a new raster was being filled with a value. This process can take a long time in cases with a large raster and the above message was confusing when used in the context of another function, like `convolve_2d`. This PR changes the log message to report the target raster, the fill value, and the percent complete rounded to two decimal points:

```
2020-08-22 17:35:37,884 (5994) INFO pygeoprocessing.geoprocessing [<lambda>:911] filling new raster convolve_out.tif with 0 -- 3.58% complete
```