### PR TITLE
Modifications to improve performance of convolve_2d

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -23,9 +23,9 @@ Unreleased Changes
   This parameter defaults to ``False``.  This is a change from prior behavior,
   when the diagnostic vectors were always created, which could occupy
   significant computational time under large outflow geometries.
-* Minor performance improvmenet to ``pygeoprocessing.convolve_2d`` by
-  preventing a pre-processing step that fliled temporary rasters with zero
-  values as well as added asyncronous work distribution for kernel/signal
+* Minor performance improvement to ``pygeoprocessing.convolve_2d`` by
+  preventing a pre-processing step that initialized temporary rasters with zero
+  values as well as added asynchronous work distribution for kernel/signal
   block processing.
 
 2.0.0 (05-19-2020)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -23,6 +23,10 @@ Unreleased Changes
   This parameter defaults to ``False``.  This is a change from prior behavior,
   when the diagnostic vectors were always created, which could occupy
   significant computational time under large outflow geometries.
+* Minor performance improvmenet to ``pygeoprocessing.convolve_2d`` by
+  preventing a pre-processing step that fliled temporary rasters with zero
+  values as well as added asyncronous work distribution for kernel/signal
+  block processing.
 
 2.0.0 (05-19-2020)
 ------------------

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2522,7 +2522,6 @@ def convolve_2d(
     worker.daemon = True
     worker.start()
 
-    # used to count how many workers are still running
     n_blocks_processed = 0
 
     # this set is indexed by (x,y) tuple from iterblock offsets to check if the

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -442,7 +442,7 @@ def raster_calculator(
                     float(pixels_processed) / n_pixels * 100.0),
                 _LOGGING_PERIOD)
 
-        LOGGER.info('100.0%% complete')
+        LOGGER.info('100.0% complete')
 
         if calc_raster_stats:
             LOGGER.info("signaling stats worker to terminate")
@@ -2604,7 +2604,7 @@ def convolve_2d(
             _LOGGING_PERIOD)
 
     LOGGER.info(
-        f"convolution worker 100.0%% complete on "
+        f"convolution worker 100.0% complete on "
         f"{os.path.basename(target_path)}")
 
     target_band.FlushCache()
@@ -2647,8 +2647,8 @@ def convolve_2d(
         mask_band = None
         os.remove(mask_raster_path)
         LOGGER.info(
-            "convolution nodata normalize 100.0%% complete on %s",
-            os.path.basename(target_path))
+            f"convolution nodata normalize 100.0% complete on "
+            f"{os.path.basename(target_path)}")
 
     target_band = None
     target_raster = None

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2492,7 +2492,7 @@ def convolve_2d(
     kernel_offset_list = list(iterblocks(k_path_band, offset_only=True))
     n_blocks = len(signal_offset_list) * len(kernel_offset_list)
 
-    LOGGER.debug(f'start fill work queue thread')
+    LOGGER.debug('start fill work queue thread')
 
     def _fill_work_queue():
         """Asynchronously fill the work queue."""
@@ -2511,7 +2511,7 @@ def convolve_2d(
     # limit the size of the write queue so we don't accidentally load a whole
     # array into memory, work queue is okay because it's only passing block
     # indexes
-    LOGGER.debug(f'start worker thread')
+    LOGGER.debug('start worker thread')
     write_queue = queue.Queue(10)
     worker_list = []
     worker = threading.Thread(

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2642,7 +2642,7 @@ def convolve_2d(
                         n_cols_signal * n_rows_signal),
                     os.path.basename(target_path)),
                 _LOGGING_PERIOD)
-        # delete the mask raster
+
         mask_raster = None
         mask_band = None
         os.remove(mask_raster_path)

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2428,31 +2428,7 @@ class PyGeoprocessing10(unittest.TestCase):
         target_path = os.path.join(self.workspace_dir, 'target.tif')
         pygeoprocessing.convolve_2d(
             (signal_path, 1), (kernel_path, 1), target_path,
-            n_threads=1, ignore_nodata_and_edges=False)
-        target_array = pygeoprocessing.raster_to_numpy_array(target_path)
-
-        # calculate expected result by adding up all squares, subtracting off
-        # the sides and realizing diagonals got subtracted twice
-        expected_result = test_value * (
-            n_pixels ** 2 * 9 - n_pixels * 4 * 3 + 4)
-        numpy.testing.assert_allclose(numpy.sum(target_array), expected_result)
-
-    def test_convolve_2d_multiprocess(self):
-        """PGP.geoprocessing: test convolve 2d (multiprocess)."""
-        n_pixels = 100
-        signal_array = numpy.ones((n_pixels, n_pixels), numpy.float32)
-        test_value = 0.5
-        signal_array[:] = test_value
-        target_nodata = -1
-        signal_path = os.path.join(self.workspace_dir, 'signal.tif')
-        _array_to_raster(signal_array, target_nodata, signal_path)
-        kernel_path = os.path.join(self.workspace_dir, 'kernel.tif')
-        kernel_array = numpy.ones((3, 3), numpy.float32)
-        _array_to_raster(kernel_array, target_nodata, kernel_path)
-        target_path = os.path.join(self.workspace_dir, 'target.tif')
-        pygeoprocessing.convolve_2d(
-            (signal_path, 1), (kernel_path, 1), target_path,
-            n_threads=3)
+            ignore_nodata_and_edges=False)
         target_array = pygeoprocessing.raster_to_numpy_array(target_path)
 
         # calculate expected result by adding up all squares, subtracting off
@@ -4172,7 +4148,7 @@ class PyGeoprocessing10(unittest.TestCase):
         target_path = os.path.join(self.workspace_dir, 'target.tif')
         pygeoprocessing.convolve_2d(
             (signal_path, 1), (kernel_path, 1), target_path,
-            n_threads=1, ignore_nodata_and_edges=False, mask_nodata=True)
+            ignore_nodata_and_edges=False, mask_nodata=True)
         target_array = pygeoprocessing.raster_to_numpy_array(target_path)
         target_nodata = pygeoprocessing.get_raster_info(
             target_path)['nodata'][0]


### PR DESCRIPTION
This PR is the result of experimenting with a variety of parallel processing techniques as well as pre-calculation of kernel FFTs or signal FFTs and more. By experimenting on a 75x75 kernel and a 12600x64000 signal raster, I found the following changes were helpful:
* Removed a "pre-fill" step for the target raster and mask if needed by the `ignore_nodata...` flag. Instead I added a set that determines if a particular block has been loaded before, and if not, defaults it to 0s. This saves having to fill an entire raster with zeros that just get overwritten later. In my example this saved a couple minutes of runtime off of a total runtime of around an hour.
* I found that the `_fft_cache...` functions did not significantly affect runtime performance in any way that I could measure, so I took them out.
* I added an asyncronous step that loads work into the work queue rather than stopping the main thread to do so. This allows the `_convolve_2d_worker` to start working right away rather than waiting for a full queue. This has a noticeable kickstart to the convolve function when comparing to large workloads and will have a small impact in total runtime since work can continue while work is loaded.
* I found that the addition of any more than 1 worker thread did not increase performance, so I removed the `n_threads` option. Since this is no longer an option, I removed the test that tested this functionality.
* I pushed the test for setting small absolute values to 0 to the worker rather than the main thread, this didn't make a performance difference one way or the other, but it does push all the "work" to a worker and leaves the main thread only to process data.

In all this PR also slightly reduces the footprint of this function and the complexity of the codebase.

Fixes #112 
