### PR TITLE
Allow a user-defined layer name in watershed delineation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,9 @@ Unreleased Changes
 ------------------
 * Fixed a critical bug introduced in 2.1.0 that generated invalid results in
   `convolve_2d` for any raster larger than 256x256.
+* Added an optional parameter, ``target_layer_name`` to
+  ``pygeoprocessing.routing.delineate_watersheds_d8`` for cases where a caller
+  would like to define the output layer name.
 
 2.1.0 (2020-08-25)
 ------------------

--- a/src/pygeoprocessing/routing/watershed.pyx
+++ b/src/pygeoprocessing/routing/watershed.pyx
@@ -624,7 +624,8 @@ def _split_geometry_into_seeds(
 def delineate_watersheds_d8(
         d8_flow_dir_raster_path_band, outflow_vector_path,
         target_watersheds_vector_path, working_dir=None,
-        write_diagnostic_vector=False, remove_temp_files=True):
+        write_diagnostic_vector=False, remove_temp_files=True,
+        target_layer_name='watersheds'):
     """Delineate watersheds for a vector of geometries using D8 flow dir.
 
     Parameters:
@@ -651,6 +652,9 @@ def delineate_watersheds_d8(
             outflow geometries cover many pixels.
         remove_temp_files=True (bool): Whether to remove the created temp
             directory at the end of the watershed delineation run.
+        target_layer_name='watersheds' (string): The string name to use for
+            the watersheds layer.  This layer name may be named anything
+            except for "polygonized_watersheds".
 
     Returns
         ``None``
@@ -708,7 +712,7 @@ def delineate_watersheds_d8(
     # technically not supported by the GPKG standard although GDAL
     # allows it for the time being.
     watersheds_layer = watersheds_vector.CreateLayer(
-        'watersheds', watersheds_srs, ogr.wkbUnknown)
+        target_layer_name, watersheds_srs, ogr.wkbUnknown)
     index_field = ogr.FieldDefn('ws_id', ogr.OFTInteger)
     index_field.SetWidth(24)
     polygonized_watersheds_layer.CreateField(index_field)

--- a/tests/test_watershed_delineation.py
+++ b/tests/test_watershed_delineation.py
@@ -157,10 +157,11 @@ class WatershedDelineationTests(unittest.TestCase):
             self.workspace_dir, 'watersheds.gpkg')
 
         pygeoprocessing.routing.delineate_watersheds_d8(
-            (flow_dir_path, 1), outflow_vector_path, target_watersheds_path)
+            (flow_dir_path, 1), outflow_vector_path, target_watersheds_path,
+            target_layer_name='watersheds_something')
 
         watersheds_vector = gdal.OpenEx(target_watersheds_path, gdal.OF_VECTOR)
-        watersheds_layer = watersheds_vector.GetLayer('watersheds')
+        watersheds_layer = watersheds_vector.GetLayer('watersheds_something')
         self.assertEqual(watersheds_layer.GetFeatureCount(), 4)
 
         # All features should have the same watersheds, both in area and


### PR DESCRIPTION
This PR allows layer names to be defined in watershed delineation according to a user-defined parameter.  This is mostly useful as an addition to https://github.com/natcap/invest/issues/56 for use in DelineateIt.  Once this PR is merged, and the feature released, we'll also need to update DelineateIt to use this new feature.

Fixes #119 