### PR TITLE
Testing for an invalid warp option. RE:#122

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 Release History
 ===============
 
+Unreleased Changes
+------------------
+* ``pygeoprocessing.warp_raster`` now raises a ``ValueError`` when an invalid
+  resampling method is provided.
+
 2.1.1 (2020-09-16)
 ------------------
 * Fixed a critical bug introduced in 2.1.0 that generated invalid results in

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1971,6 +1971,12 @@ def warp_raster(
             'PIXELTYPE' not in ' '.join(raster_creation_options)):
         raster_creation_options.append('PIXELTYPE=SIGNEDBYTE')
 
+    # WarpOptions.this is None when an invalid option is passed, and it's a
+    # truthy SWIG proxy object when it's given a valid resample arg.
+    if not gdal.WarpOptions(resampleAlg=resample_method)[0].this:
+        raise ValueError(
+            f'Invalid resample method: "{resample_method}"')
+
     gdal.Warp(
         warped_raster_path, base_raster,
         format=raster_driver_creation_tuple[0],

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -1174,6 +1174,24 @@ class PyGeoprocessing10(unittest.TestCase):
                 pygeoprocessing.raster_to_numpy_array(
                     target_raster_path)).all())
 
+    def test_warp_raster_invalid_resample_alg(self):
+        """PGP.geoprocessing: error on invalid resample algorithm."""
+        pixel_a_matrix = numpy.ones((5, 5), numpy.int16)
+        target_nodata = -1
+        base_a_path = os.path.join(self.workspace_dir, 'base_a.tif')
+        _array_to_raster(
+            pixel_a_matrix, target_nodata, base_a_path)
+
+        target_raster_path = os.path.join(self.workspace_dir, 'target_a.tif')
+        base_a_raster_info = pygeoprocessing.get_raster_info(base_a_path)
+
+        with self.assertRaises(ValueError) as context:
+            pygeoprocessing.warp_raster(
+                base_a_path, base_a_raster_info['pixel_size'], target_raster_path,
+                'not_an_algorithm', n_threads=1)
+
+        self.assertIn('Invalid resample method', str(context.exception))
+
     def test_warp_raster_unusual_pixel_size(self):
         """PGP.geoprocessing: warp on unusual pixel types and sizes."""
         pixel_a_matrix = numpy.ones((1, 1), numpy.byte)


### PR DESCRIPTION
This PR introduces a fix for an error that cost me a lot of time in reimplementing Coastal Blue Carbon in InVEST (https://github.com/natcap/invest/issues/209), where passing an invalid resampling method to `gdal.Warp` would cause a cryptic error to be raised.  This workaround preempts the cryptic error by specifically checking the given `resample_method` by passing it to GDAL for parsing, raising a `ValueError` if it's not recognized.

This should require minimal, if any, maintenance in future GDAL updates, since it relies on GDAL's checking of the resample method.

Fixes #122 