### PR TITLE
Fix convolution work queue memory leak

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ Unreleased Changes
 ------------------
 * ``pygeoprocessing.warp_raster`` now raises a ``ValueError`` when an invalid
   resampling method is provided.
+* Fixed ``convolve_2d`` memory leak when kernel or signal rasters were very
+  large.
 
 2.1.1 (2020-09-16)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,8 +5,8 @@ Unreleased Changes
 ------------------
 * ``pygeoprocessing.warp_raster`` now raises a ``ValueError`` when an invalid
   resampling method is provided.
-* Fixed ``convolve_2d`` memory leak when kernel or signal rasters were very
-  large.
+* Fixed issue in ``convolve_2d`` that would cause excessive memory use
+  leading to out of memory errors.
 
 2.1.1 (2020-09-16)
 ------------------

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2515,7 +2515,9 @@ def convolve_2d(
             kernel_block[numpy.isclose(kernel_block, kernel_nodata)] = 0.0
         kernel_sum += numpy.sum(kernel_block)
 
-    work_queue = queue.Queue()
+    # limit the size of the work queue since a large kernel / signal with small
+    # block size can have a large memory impact when queuing offset lists.
+    work_queue = queue.Queue(10)
     signal_offset_list = list(iterblocks(s_path_band, offset_only=True))
     kernel_offset_list = list(iterblocks(k_path_band, offset_only=True))
     n_blocks = len(signal_offset_list) * len(kernel_offset_list)
@@ -2537,8 +2539,7 @@ def convolve_2d(
     fill_work_queue_worker.start()
 
     # limit the size of the write queue so we don't accidentally load a whole
-    # array into memory, work queue is okay because it's only passing block
-    # indexes
+    # array into memory
     LOGGER.debug('start worker thread')
     write_queue = queue.Queue(10)
     worker = threading.Thread(


### PR DESCRIPTION
Given large kernel and signal rasters the `work_queue` was loading a very large number of offset lists at once causing a memory leak. Restricting that queue to size 10.

Fixes #125 