### PR TITLE
Fixes #124, assessing a _safe_rmtree and updating history

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+Unreleased Changes
+------------------
+* Guarding against ``FileNotFoundError`` being raised due to a Python race
+  condition bug in ``shutil.rmtree`` described here:
+  https://bugs.python.org/issue29699
+
 2.1.1 (2020-09-16)
 ------------------
 * Fixed a critical bug introduced in 2.1.0 that generated invalid results in

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -7,7 +7,6 @@ import math
 import os
 import pprint
 import queue
-import shutil
 import sys
 import tempfile
 import threading
@@ -15,6 +14,7 @@ import time
 
 from . import geoprocessing_core
 from .geoprocessing_core import DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS
+from .geoprocessing_core import _safe_rmtree
 from osgeo import gdal
 from osgeo import ogr
 from osgeo import osr
@@ -1998,7 +1998,7 @@ def warp_raster(
             target_mask_value=None, working_dir=temp_working_dir,
             all_touched=False,
             raster_driver_creation_tuple=raster_driver_creation_tuple)
-        shutil.rmtree(temp_working_dir)
+        _safe_rmtree(temp_working_dir)
 
 
 def rasterize(
@@ -2677,7 +2677,7 @@ def convolve_2d(
     if s_nodata is not None and ignore_nodata_and_edges:
         # there's a working directory only if we need to remember the nodata
         # pixels
-        shutil.rmtree(mask_dir)
+        _safe_rmtree(mask_dir)
 
 
 def iterblocks(

--- a/src/pygeoprocessing/geoprocessing_core.pyx
+++ b/src/pygeoprocessing/geoprocessing_core.pyx
@@ -947,33 +947,33 @@ def _raster_band_percentile_double(
     return result_list
 
 
-def _safe_rmtree(path):
-    """Attempts to remove a file path and logs a warning if it fails.
+def _safe_rmtree(dir_path):
+    """Attempt remove directory via shutil.rmtree and log warning on failure.
 
     There is a possible bug in shutil.rmtree that can raise a FileNotFound
     error even if the removal of a directory is possible and it removed it
     see: https://bugs.python.org/issue29699. This function is effectively a
-    guard against that bug and logs a warning if the file path could not
+    guard against that bug and logs a warning if dir_path could not
     be removed.
 
     Args:
-        path (str): represents a file path to remove
+        dir_path (str): path to directory to remove
 
     Returns:
         None
     """
     try:
-        # check if the path exists first before removing so we know if we
+        # check if the dir_path exists before removing so we know if we
         # get a FileNotFoundError we can be confident it is related to
         # Python issue29699.
-        if os.path.exists(path):
-            shutil.rmtree(path)
+        if os.path.isdir(dir_path):
+            shutil.rmtree(dir_path)
     except FileNotFoundError:
-        # check if the dir path is not there to verify if there was an
+        # check if the dir_path is not there to verify if there was an
         # incorrect exception raised due to Python issue29699. If the path
         # does not exist assume the directory was removed correctly.
-        if os.path.exists(path):
-            LOGGER.warn(f'unable to remove {path}')
+        if os.path.isdir(dir_path):
+            LOGGER.warning(f'unable to remove {dir_path}')
     except OSError:
         LOGGER.exception(
-            f'Ignoring unexpected OSError when removing {path}.')
+            f'Ignoring unexpected OSError when removing {dir_path}.')

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -18,7 +18,6 @@ is encoded as:
 """
 import logging
 import os
-import shutil
 import tempfile
 import time
 
@@ -37,6 +36,8 @@ from libcpp.set cimport set as cset
 from libcpp.stack cimport stack
 from osgeo import gdal
 import numpy
+
+from ..geoprocessing_core import _safe_rmtree
 import pygeoprocessing
 
 LOGGER = logging.getLogger(__name__)
@@ -947,7 +948,7 @@ def fill_pits(
 
     pit_mask_managed_raster.close()
     flat_region_mask_managed_raster.close()
-    shutil.rmtree(working_dir_path)
+    _safe_rmtree(working_dir_path)
     LOGGER.info('%.1f%% complete', 100.0)
 
 
@@ -1310,7 +1311,7 @@ def flow_dir_d8(
     flat_region_mask_managed_raster.close()
     dem_managed_raster.close()
     plateau_distance_managed_raster.close()
-    shutil.rmtree(working_dir_path)
+    _safe_rmtree(working_dir_path)
     LOGGER.info('%.1f%% complete', 100.0)
 
 
@@ -2024,7 +2025,7 @@ def flow_dir_mfd(
     flat_region_mask_managed_raster.close()
     dem_managed_raster.close()
     plateau_distance_managed_raster.close()
-    shutil.rmtree(working_dir_path)
+    _safe_rmtree(working_dir_path)
     LOGGER.info('%.1f%% complete', 100.0)
 
 
@@ -2303,10 +2304,7 @@ def flow_accumulation_mfd(
     if weight_raster is not None:
         weight_raster.close()
     visited_managed_raster.close()
-    try:
-        shutil.rmtree(tmp_dir)
-    except OSError:
-        LOGGER.exception("couldn't remove temp dir")
+    _safe_rmtree(tmp_dir)
     LOGGER.info('%.1f%% complete', 100.0)
 
 

--- a/src/pygeoprocessing/routing/watershed.pyx
+++ b/src/pygeoprocessing/routing/watershed.pyx
@@ -2,7 +2,6 @@
 # cython: language_level=3
 import logging
 import os
-import shutil
 import tempfile
 import time
 
@@ -26,6 +25,7 @@ import shapely.geometry
 import shapely.prepared
 import shapely.wkb
 
+from ..geoprocessing_core import _safe_rmtree
 import pygeoprocessing
 
 LOGGER = logging.getLogger(__name__)
@@ -1001,5 +1001,5 @@ def delineate_watersheds_d8(
     source_vector = None
 
     if remove_temp_files:
-        shutil.rmtree(working_dir_path)
+        _safe_rmtree(working_dir_path)
     LOGGER.info('Watershed delineation complete')


### PR DESCRIPTION
This PR wraps all calls to `shutil.rmtree` in a "safe" version that guards against the Python race condition related to `shutil.rmtree` described in https://bugs.python.org/issue29699 and updates `HISTORY.rst` indicating that.

On my own I can't recreate that issue easily in a test suite so I think it's safe to leave it without a test... that function is called by many other regression covered tests in PyGeoprocessing, but please ensure to inspect the code flow carefully since there's no easy way to test that it covers that issue.