### PR TITLE
133 Pass metadata to mask_raster

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,9 @@ Unreleased Changes
 ------------------
 * ``pygeoprocessing.warp_raster`` now raises a ``ValueError`` when an invalid
   resampling method is provided.
+* Fixed bug in ``pygeoprocessing.warp_raster`` that would not properly handle
+  GDAL Byte type signing when masking warped raster with a vector.
+  resampling method is provided.
 * Fixed issue in ``convolve_2d`` that would cause excessive memory use
   leading to out of memory errors.
 * Fixed issue in ``convolve_2d`` that could lead to a file removal race

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,6 @@ Unreleased Changes
   resampling method is provided.
 * Fixed bug in ``pygeoprocessing.warp_raster`` that would not properly handle
   GDAL Byte type signing when masking warped raster with a vector.
-  resampling method is provided.
 * Fixed issue in ``convolve_2d`` that would cause excessive memory use
   leading to out of memory errors.
 * Fixed issue in ``convolve_2d`` that could lead to a file removal race

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2030,6 +2030,10 @@ def warp_raster(
         callback_data=[target_raster_path])
 
     if vector_mask_options:
+        # Make sure the raster creation options passed to ``mask_raster`` 
+        # reflect any metadata updates
+        updated_raster_driver_creation_tuple = (
+            raster_driver_creation_tuple[0], tuple(raster_creation_options))
         # there was a cutline vector, so mask it out now, otherwise target
         # is already the result.
         mask_raster(
@@ -2039,7 +2043,7 @@ def warp_raster(
             where_clause=mask_vector_where_filter,
             target_mask_value=None, working_dir=temp_working_dir,
             all_touched=False,
-            raster_driver_creation_tuple=raster_driver_creation_tuple)
+            raster_driver_creation_tuple=updated_raster_driver_creation_tuple)
         shutil.rmtree(temp_working_dir)
 
 


### PR DESCRIPTION
This PR fixes the bug where `align_and_resize_datastack` would mishandle GDAL Byte rasters with `PIXELTYPE=SIGNEDBYTE` when masking with a vector. Before the metadata `PIXELTYPE=SIGNEDBYTE` was not being passed through to `mask_raster`, and now it is.

Fixes #133 