### PR TITLE
fixes #138 allowing for true/false setting, added a logger debug for …

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,15 @@
 Release History
 ===============
 
+Unreleased Changes
+------------------
+* Changed parameters in ``convolve_2d`` to allow API to set
+  ``ignore_nodata_and_edges=True`` while ``mask_nodata=False`` and updated
+  docstring to indicate this is useful in cases such as filling nodata holes
+  in missing datasets. Additionally added a logger ``debug`` message to note
+  this "unusual" setting of these parameters in case of accidental usage
+  which could be noted during development.
+
 2.1.2 (2020-12-03)
 ------------------
 * ``pygeoprocessing.warp_raster`` now raises a ``ValueError`` when an invalid

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2475,11 +2475,9 @@ def convolve_2d(
             setting ``ignore_nodata_and_edges`` to ``True`` while setting
             ``mask_nodata`` to ``False`` can allow for a technique involving
             distance weighted averaging to define areas that would otherwise
-            be nodata, however be careful in cases where the kernel does not
+            be nodata. Be careful in cases where the kernel does not
             extend over any valid non-nodata area since the result can be
-            numerical infinity or NaNs. would be a nonsensical result and
-            would result in exposing the numerical noise where the nodata
-            values were ignored. An exception is thrown in this case.
+            numerical infinity or NaNs.
         target_datatype (GDAL type): a GDAL raster type to set the output
             raster type to, as well as the type to calculate the convolution
             in.  Defaults to GDT_Float64.  Note signed byte is not


### PR DESCRIPTION
This PR allows the user to set `ignore_nodata_and_edges=True` and `mask_nodata=False`, describes in the docstring why this is useful, adds a "debug" logger message to help during development in case this setting is used accidentally, and added a test case to cover the functionality in the way it would be expected to be used.