### PR TITLE
Fixes issue #141 

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,7 +12,7 @@ Unreleased Changes
 * Fixed issue in zonal statistics that could cause the aggregate vector to be
   locked due to a dereferencing race condition. This was present in some
   cases with a flaky unit test but could have been seen in practice if the
-  vector was deleted immediately after the call ton ``zonal_statistics``.
+  vector was deleted immediately after the call to ``zonal_statistics``.
 
 2.1.2 (2020-12-03)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,10 @@ Unreleased Changes
   in missing datasets. Additionally added a logger ``debug`` message to note
   this "unusual" setting of these parameters in case of accidental usage
   which could be noted during development.
+* Fixed issue in zonal statistics that could cause the aggregate vector to be
+  locked due to a dereferencing race condition. This was present in some
+  cases with a flaky unit test but could have been seen in practice if the
+  vector was deleted immediately after the call ton ``zonal_statistics``.
 
 2.1.2 (2020-12-03)
 ------------------


### PR DESCRIPTION
This PR fixes a race issue when releasing `zonal_statistics`'s aggregate vector object that occured when `pytest` ran with live logging -- essentially a race condition when deleting the test workspace while the aggregate vector still had an open reference somewhere.

This PR addresses all the possible places that a leaked `ogr` object could exist that was not explicitly set to `None` before the function terminates.
