### PR TITLE
Bugfix/stats worker core dump 146

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -23,8 +23,10 @@ Unreleased Changes
   memory corruption.
 * Exposing a ``use_shared_memory`` flag on ``raster_calculator`` to allow
   a user to use shared memory objects when calculating statistics. This
-  feature creates a significant runtime improvement but has been unstable
-  in multiprocessing configurations. It is defaulted to ``False``.
+  feature is only available for Python >= 3.8. If available, this
+  feature creates a significant runtime improvement but can be unstable
+  in multiprocessing configurations. For this reason it is set to
+  ``False`` as the default value.
 * Added a ``max_timeout`` parameter to ``convolve_2d`` and
   ``raster_calculator`` to allow the user to specify the maximum amount of
   time to wait for worker threads to terminate. In normal operation these

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -25,6 +25,13 @@ Unreleased Changes
   a user to use shared memory objects when calculating statistics. This
   feature creates a significant runtime improvement but has been unstable
   in multiprocessing configurations. It is defaulted to ``False``.
+* Added a ``max_timeout`` parameter to ``convolve_2d`` and
+  ``raster_calculator`` to allow the user to specify the maximum amount of
+  time to wait for worker threads to terminate. In normal operation these
+  threads should terminate in a short amount of time but are generously
+  timed with the ``pygeoprocessing._MAX_TIMEOUT`` parameter. This parameter
+  allows a user to tune in cases that may involve significant latency such
+  as in a heavy multiprocess environment.
 
 2.1.2 (2020-12-03)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -19,6 +19,12 @@ Unreleased Changes
   considered a plateau otherwise a drain into or out of the pixel is
   resolved. Testing is close allowed a hydrological pit to remain since it
   was "close" to the same height as a draining pixel.
+* Removing all instances of ``__swig_destroy__`` to prevent multiprocessing
+  memory corruption.
+* Exposing a ``use_shared_memory`` flag on ``raster_calculator`` to allow
+  a user to use shared memory objects when calculating statistics. This
+  feature creates a significant runtime improvement but has been unstable
+  in multiprocessing configurations. It is defaulted to ``False``.
 
 2.1.2 (2020-12-03)
 ------------------

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -86,7 +86,8 @@ DEFAULT_OSR_AXIS_MAPPING_STRATEGY = osr.OAMS_TRADITIONAL_GIS_ORDER
 def raster_calculator(
         base_raster_path_band_const_list, local_op, target_raster_path,
         datatype_target, nodata_target,
-        calc_raster_stats=True, largest_block=_LARGEST_ITERBLOCK,
+        calc_raster_stats=True, use_shared_memory=False,
+        largest_block=_LARGEST_ITERBLOCK, max_timeout=_MAX_TIMEOUT,
         raster_driver_creation_tuple=DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS):
     """Apply local a raster operation on a stack of rasters.
 
@@ -137,12 +138,16 @@ def raster_calculator(
             target raster.
         calc_raster_stats (boolean): If True, calculates and sets raster
             statistics (min, max, mean, and stdev) for target raster.
+        use_shared_memory (boolean): If True, uses Python Multiprocessing
+            shared memory to calculate raster stats for faster performance.
         largest_block (int): Attempts to internally iterate over raster blocks
             with this many elements.  Useful in cases where the blocksize is
             relatively small, memory is available, and the function call
             overhead dominates the iteration.  Defaults to 2**20.  A value of
             anything less than the original blocksize of the raster will
             result in blocksizes equal to the original size.
+        max_timeout (float): amount of time in seconds to wait for stats
+            worker thread to join. Default is _MAX_TIMEOUT.
         raster_driver_creation_tuple (tuple): a tuple containing a GDAL driver
             name string as the first element and a GDAL creation options
             tuple/list as the second. Defaults to
@@ -455,7 +460,7 @@ def raster_calculator(
                     target_block = target_block[target_block != nodata_target]
                 target_block = target_block.astype(numpy.float64).flatten()
 
-                if sys.version_info >= (3, 8):
+                if sys.version_info >= (3, 8) and use_shared_memory:
                     shared_memory_array = numpy.ndarray(
                         target_block.shape, dtype=target_block.dtype,
                         buffer=shared_memory.buf)
@@ -478,39 +483,46 @@ def raster_calculator(
 
         if calc_raster_stats:
             LOGGER.info("Waiting for raster stats worker result.")
-            stats_worker_thread.join(_MAX_TIMEOUT)
+            stats_worker_thread.join(max_timeout)
             if stats_worker_thread.is_alive():
+                LOGGER.error("stats_worker_thread.join() timed out")
                 raise RuntimeError("stats_worker_thread.join() timed out")
-            payload = stats_worker_queue.get(True, _MAX_TIMEOUT)
+            payload = stats_worker_queue.get(True, max_timeout)
             if payload is not None:
                 target_min, target_max, target_mean, target_stddev = payload
                 target_band.SetStatistics(
                     float(target_min), float(target_max), float(target_mean),
                     float(target_stddev))
                 target_band.FlushCache()
+    except Exception:
+        LOGGER.exception('exception encountered in raster_calculator')
+        raise
     finally:
         # This block ensures that rasters are destroyed even if there's an
         # exception raised.
         base_band_list[:] = []
-        for raster in base_raster_list:
-            gdal.Dataset.__swig_destroy__(raster)
         base_raster_list[:] = []
         target_band.FlushCache()
         target_band = None
         target_raster.FlushCache()
-        gdal.Dataset.__swig_destroy__(target_raster)
         target_raster = None
 
         if calc_raster_stats and stats_worker_thread:
             if stats_worker_thread.is_alive():
-                stats_worker_queue.put(None, True, _MAX_TIMEOUT)
+                stats_worker_queue.put(None, True, max_timeout)
                 LOGGER.info("Waiting for raster stats worker result.")
-                stats_worker_thread.join(_MAX_TIMEOUT)
+                stats_worker_thread.join(max_timeout)
                 if stats_worker_thread.is_alive():
-                    raise RuntimeError("stats_worker_thread.join() timed out")
-                if sys.version_info >= (3, 8):
+                    LOGGER.error("stats_worker_thread.join() timed out")
+                    raise RuntimeError(
+                        "stats_worker_thread.join() timed out")
+                if sys.version_info >= (3, 8) and use_shared_memory:
+                    LOGGER.debug(
+                        f'unlink shared memory for process {os.getpid()}')
                     shared_memory.close()
                     shared_memory.unlink()
+                    LOGGER.debug(
+                        f'unlinked shared memory for process {os.getpid()}')
 
             # check for an exception in the workers, otherwise get result
             # and pass to writer
@@ -2432,6 +2444,7 @@ def convolve_2d(
         ignore_nodata_and_edges=False, mask_nodata=True,
         normalize_kernel=False, target_datatype=gdal.GDT_Float64,
         target_nodata=None, working_dir=None, set_tol_to_zero=1e-8,
+        max_timeout=_MAX_TIMEOUT,
         raster_driver_creation_tuple=DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS):
     """Convolve 2D kernel over 2D signal.
 
@@ -2494,6 +2507,8 @@ def convolve_2d(
             sometimes result in "numerical zero", such as -1.782e-18 that
             cannot be tolerated by users of this function. If `None` no
             adjustment will be done to output values.
+        max_timeout (float): maximum amount of time to wait for worker thread
+            to terminate.
         raster_driver_creation_tuple (tuple): a tuple containing a GDAL driver
             name string as the first element and a GDAL creation options
             tuple/list as the second. Defaults to a GTiff driver tuple
@@ -2627,7 +2642,7 @@ def convolve_2d(
              left_index_result, right_index_result,
              top_index_result, bottom_index_result) = write_payload
         else:
-            worker.join(_MAX_TIMEOUT)
+            worker.join(max_timeout)
             break
 
         output_array = numpy.empty(

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -140,6 +140,8 @@ def raster_calculator(
             statistics (min, max, mean, and stdev) for target raster.
         use_shared_memory (boolean): If True, uses Python Multiprocessing
             shared memory to calculate raster stats for faster performance.
+            This feature is available for Python >= 3.8 and will otherwise
+            be ignored for earlier versions of Python.
         largest_block (int): Attempts to internally iterate over raster blocks
             with this many elements.  Useful in cases where the blocksize is
             relatively small, memory is available, and the function call

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -294,7 +294,7 @@ def raster_calculator(
         # tuple, 1d ndarray, 2d ndarray, or (value, 'raw') tuple.
         if _is_raster_path_band_formatted(value):
             # it's a raster/path band, keep track of open raster and band
-            # for later so we can __swig_destroy__ them.
+            # for later so we can `None` them.
             base_raster_list.append(gdal.OpenEx(value[0], gdal.OF_RASTER))
             base_band_list.append(
                 base_raster_list[-1].GetRasterBand(value[1]))
@@ -2154,7 +2154,7 @@ def rasterize(
         raster, [1], layer, burn_values=burn_values,
         options=option_list, callback=rasterize_callback)
     raster.FlushCache()
-    gdal.Dataset.__swig_destroy__(raster)
+    raster = None
 
     if result != 0:
         raise RuntimeError('Rasterize returned a nonzero exit code.')
@@ -2860,7 +2860,6 @@ def iterblocks(
                 yield (offset_dict, band.ReadAsArray(**offset_dict))
 
     band = None
-    gdal.Dataset.__swig_destroy__(raster)
     raster = None
 
 

--- a/src/pygeoprocessing/geoprocessing_core.pyx
+++ b/src/pygeoprocessing/geoprocessing_core.pyx
@@ -563,7 +563,8 @@ def stats_worker(stats_work_queue, expected_blocks):
             payload = stats_work_queue.get()
             if payload is None:
                 break
-            if sys.version_info >= (3, 8):
+            if len(payload) == 3:
+                # Payload is a shared memory pointer
                 shape, dtype, existing_shm = payload
                 block = numpy.ndarray(
                     shape, dtype=dtype, buffer=existing_shm.buf)

--- a/src/pygeoprocessing/geoprocessing_core.pyx
+++ b/src/pygeoprocessing/geoprocessing_core.pyx
@@ -524,8 +524,6 @@ def calculate_slope(
 
     dem_band = None
     target_slope_band = None
-    gdal.Dataset.__swig_destroy__(dem_raster)
-    gdal.Dataset.__swig_destroy__(target_slope_raster)
     dem_raster = None
     target_slope_raster = None
 

--- a/src/pygeoprocessing/geoprocessing_core.pyx
+++ b/src/pygeoprocessing/geoprocessing_core.pyx
@@ -562,9 +562,10 @@ def stats_worker(stats_work_queue, expected_blocks):
             if payload is None:
                 break
             if isinstance(payload, numpy.ndarray):
+                # if the payload is a normal array take it as the array block
                 block = payload
             else:
-                # Payload is a shared memory pointer
+                # if not an ndarray, it is a shared memory pointer tuple
                 shape, dtype, existing_shm = payload
                 block = numpy.ndarray(
                     shape, dtype=dtype, buffer=existing_shm.buf)

--- a/src/pygeoprocessing/geoprocessing_core.pyx
+++ b/src/pygeoprocessing/geoprocessing_core.pyx
@@ -563,13 +563,13 @@ def stats_worker(stats_work_queue, expected_blocks):
             payload = stats_work_queue.get()
             if payload is None:
                 break
-            if len(payload) == 3:
+            if isinstance(payload, numpy.ndarray):
+                block = payload
+            else:
                 # Payload is a shared memory pointer
                 shape, dtype, existing_shm = payload
                 block = numpy.ndarray(
                     shape, dtype=dtype, buffer=existing_shm.buf)
-            else:
-                block = payload
             if block.size == 0:
                 continue
             n_elements = block.size

--- a/src/pygeoprocessing/multiprocessing/raster_calculator.py
+++ b/src/pygeoprocessing/multiprocessing/raster_calculator.py
@@ -460,7 +460,7 @@ def raster_calculator(
         # tuple, 1d ndarray, 2d ndarray, or (value, 'raw') tuple.
         if _is_raster_path_band_formatted(value):
             # it's a raster/path band, keep track of open raster and band
-            # for later so we can __swig_destroy__ them.
+            # for later so we can `None` them.
             base_canonical_arg_list.append(
                 RasterPathBand(value[0], value[1]))
         elif isinstance(value, numpy.ndarray):

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -1688,7 +1688,8 @@ class PyGeoprocessing10(unittest.TestCase):
 
         pygeoprocessing.raster_calculator(
             [(base_path, 1)], passthrough, target_path,
-            gdal.GDT_Int32, target_nodata, calc_raster_stats=True)
+            gdal.GDT_Int32, target_nodata, calc_raster_stats=True,
+            use_shared_memory=True)
 
         self.assertTrue(
             numpy.isclose(
@@ -1706,7 +1707,8 @@ class PyGeoprocessing10(unittest.TestCase):
 
         pygeoprocessing.multiprocessing.raster_calculator(
             [(base_path, 1)], arithmetic_wrangle, target_path,
-            gdal.GDT_Int32, target_nodata, calc_raster_stats=True)
+            gdal.GDT_Int32, target_nodata, calc_raster_stats=True,
+            use_shared_memory=True)
 
         self.assertTrue(
             numpy.isclose(


### PR DESCRIPTION
This PR fixes a bug I discovered when examining the results of a ``core`` file that dumped when running pygeoprocessing in a multiprocessing enviornment with 64 processes and thousands of tasks. Occasionally some of these processes would terminate and the core file suggested it was a memory corruption inside of ``stats_worker``. That function uses shared memory objects and also is one of the remaining ``__swig_destroy__`` users in pygeoprocessing. I've made shared memory an optional flag and removed all the ``__swig...`` calls throughout PyGeoprocessing.

It's difficult to reproduce this so I don't have a way to add a test that wouldn't take significant cpu resources and runtime. Instead I've modified some tests to inclucde the ``use_shared_memory`` flag.

Closes #146 