### PR TITLE
Removing duplicate 'uses'. RE:#154

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,7 +21,6 @@ jobs:
           fetch-depth: 0
 
     - name: setup-miniconda
-      uses: goanpeca/setup-miniconda@v1.1.2
       uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: pyenv


### PR DESCRIPTION
The workflow syntax wasn't correct, and Actions doesn't fail  loudly enough when this happens.

Fixes #154 