### PR TITLE
fixes #162 just bumping up precision

### DIFF
--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -3848,7 +3848,7 @@ def calculate_subwatershed_boundary(
     n_cols, n_rows = discovery_info['raster_size']
 
     geotransform = discovery_info['geotransform']
-    cdef float g0, g1, g2, g3, g4, g5
+    cdef double g0, g1, g2, g3, g4, g5
     g0, g1, g2, g3, g4, g5 = geotransform
 
     if discovery_info['projection_wkt']:
@@ -3875,8 +3875,8 @@ def calculate_subwatershed_boundary(
     watershed_layer.StartTransaction()
 
     cdef int x_l, y_l, outflow_dir
-    cdef float x_f, y_f
-    cdef float x_first, y_first, x_p, y_p
+    cdef double x_f, y_f
+    cdef double x_first, y_first, x_p, y_p
     cdef long discovery, finish
 
     cdef time_t last_log_time = ctime(NULL)


### PR DESCRIPTION
This PR bumps up the precision of the floating point values used to keep track of the position in the raster to doubles so that they match the precision used by `gdal.ApplyGeotransform`. This can fix an issue where coordinates are so large that the precision transforming them by a geotransform is significantly different than calculating the same coordinates manually.

I didn't note anything in the history because we haven't released this feature yet. More controversially, I didn't add a test for this either because what you'd find is that it takes a LONG time to loop and you end up with a polygon that is way too large. I had a check in there already as a worst case scenario that dumps a message to a log, that's how I saw this. To effectively test for this I'd have to build in functionality to terminate the watershed delineation early and then inspect the result. That would turn this 4 line PR into a much larger one... I'd rather not do that for something that hasn't been released yet that's as simple as match the floating point types.