### PR TITLE
Feature/outlet at confluence 165

### DIFF
--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -3824,18 +3824,20 @@ def calculate_subwatershed_boundary(
         strahler_stream_vector_path (str): path to stream segment vector
         target_watershed_boundary_vector_path (str): path to created vector
             of linestring for watershed boundaries. Contains the fields:
-            "stream_id": this is the stream ID from the
-                ``strahler_stream_vector_path`` that corresponds to this
-                subwatershed.
-            "terminated_early": if set to 1 this watershed generation was
-                terminated before it could be complete. This value should
-                always be 0 unless something is wrong as a software bug
-                or some degenerate case of data.
-            "outlet_x", "outlet_y": this is the x/y coordinate in raster
-                space of the outlet of the watershed. It can be useful when
-                determining other properties about the watershed when indexed
-                with underlying raster data that created the streams in
-                ``strahler_stream_vector_path``.
+
+            * "stream_id": this is the stream ID from the
+              ``strahler_stream_vector_path`` that corresponds to this
+              subwatershed.
+            * "terminated_early": if set to 1 this watershed generation was
+              terminated before it could be complete. This value should
+              always be 0 unless something is wrong as a software bug
+              or some degenerate case of data.
+            * "outlet_x", "outlet_y": this is the x/y coordinate in raster
+              space of the outlet of the watershed. It can be useful when
+              determining other properties about the watershed when indexed
+              with underlying raster data that created the streams in
+              ``strahler_stream_vector_path``.
+
         max_steps_per_watershed (int): maximum number of steps to take when
             defining a watershed boundary. Useful if the DEM is large and
             degenerate or some other user known condition to limit long large

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -3816,7 +3816,7 @@ def calculate_subwatershed_boundary(
         strahler_stream_vector_path, target_watershed_boundary_vector_path,
         max_steps_per_watershed=1000000,
         outlet_at_confluence=False):
-    """Calculate a stringline boundary around all subwatersheds.
+    """Calculate a linestring boundary around all subwatersheds.
 
     Subwatersheds start where the ``strahler_stream_vector`` has a junction
     starting at this highest upstream to lowest and ending at the outlet of
@@ -3827,7 +3827,7 @@ def calculate_subwatershed_boundary(
             raster
         strahler_stream_vector_path (str): path to stream segment vector
         target_watershed_boundary_vector_path (str): path to created vector
-            of stringline for watershed boundaries. Contains the fields:
+            of linestring for watershed boundaries. Contains the fields:
             "stream_id": this is the stream ID from the
                 ``strahler_stream_vector_path`` that corresponds to this
                 subwatershed.

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -3038,6 +3038,10 @@ def extract_strahler_streams_d8(
             stream segment outlet.
         * "ds_y" (int): the downstream y coordinate in raster space for the
             stream segment outlet.
+        * "ds_x_1" (int): the downstream x coordinate for one pixel upstream
+            from the stream segment outlet raster space coordinates.
+        * "ds_y_1" (int): the downstream y coordinate for one pixel upstream
+            from the stream segment outlet raster space coordinates.
         * "us_x" (int): the upstream x coordinate in raster space for the
             stream segment outlet.
         * "us_y" (int): the upstream y coordinate in raster space for the

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -3962,7 +3962,7 @@ def calculate_subwatershed_boundary(
             else:
                 working_stack.pop()
                 # the `not outlet_at_confluence` bit allows us to seed
-                # even if the order is 1, otherwise confluences fill fill
+                # even if the order is 1, otherwise confluences fill
                 # the order 1 streams
                 if (working_feature.GetField('order') > 1 or
                         not outlet_at_confluence):

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -3035,18 +3035,14 @@ def extract_strahler_streams_d8(
         * "upstream_d8_dir" (int): a bookkeeping parameter from stream
             calculations that is left in due to the overhead
             of deleting a field.
-        * "ds_x" (int): the downstream x coordinate in raster space for the
-            stream segment outlet.
-        * "ds_y" (int): the downstream y coordinate in raster space for the
-            stream segment outlet.
-        * "ds_x_1" (int): the downstream x coordinate for one pixel upstream
-            from the stream segment outlet raster space coordinates.
-        * "ds_y_1" (int): the downstream y coordinate for one pixel upstream
-            from the stream segment outlet raster space coordinates.
-        * "us_x" (int): the upstream x coordinate in raster space for the
-            stream segment outlet.
-        * "us_y" (int): the upstream y coordinate in raster space for the
-            stream segment outlet.
+        * "ds_x" (int): the raster x coordinate for the outlet.
+        * "ds_y" (int): the raster y coordinate for the outlet.
+        * "ds_x_1" (int): the x raster space coordinate that is 1 pixel
+            upstream from the outlet.
+        * "ds_y_1" (int): the y raster space coordinate that is 1 pixel
+            upstream from the outlet.
+        * "us_x" (int): the raster x coordinate for the upstream inlet.
+        * "us_y" (int): the raster y coordinate for the upstream inlet.
 
     Args:
         flow_dir_d8_raster_path_band (tuple): a path/band representing the D8

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1048,20 +1048,34 @@ class TestRouting(unittest.TestCase):
         # known to be order 2 because none of the streams can branch more
         # than once
         self.assertEqual(outlet_feature.GetField('order'), 2)
+        stream_vector = None
+        stream_layer = None
 
-        watershed_vector_path = os.path.join(
-            self.workspace_dir, 'watershed.gpkg')
+        watershed_confluence_vector_path = os.path.join(
+            self.workspace_dir, 'watershed_confluence.gpkg')
         pygeoprocessing.routing.calculate_subwatershed_boundary(
             (flow_dir_d8_path, 1), stream_vector_path,
-            watershed_vector_path)
+            watershed_confluence_vector_path, outlet_at_confluence=True)
 
-        watershed_vector = gdal.OpenEx(watershed_vector_path, gdal.OF_VECTOR)
+        watershed_vector = gdal.OpenEx(
+            watershed_confluence_vector_path, gdal.OF_VECTOR)
         watershed_layer = watershed_vector.GetLayer()
         # there should be exactly an integer half number of watersheds as
         # the length of the canyon
         self.assertEqual(watershed_layer.GetFeatureCount(), n//2)
-
         watershed_vector = None
         watershed_layer = None
-        stream_vector = None
-        stream_layer = None
+
+        watershed_confluence_vector_path = os.path.join(
+            self.workspace_dir, 'watershed_confluence.gpkg')
+        pygeoprocessing.routing.calculate_subwatershed_boundary(
+            (flow_dir_d8_path, 1), stream_vector_path,
+            watershed_confluence_vector_path, outlet_at_confluence=False)
+
+        watershed_vector = gdal.OpenEx(
+            watershed_confluence_vector_path, gdal.OF_VECTOR)
+        watershed_layer = watershed_vector.GetLayer()
+        # every stream should have a watershed
+        self.assertEqual(watershed_layer.GetFeatureCount(), n-2)
+        watershed_vector = None
+        watershed_layer = None


### PR DESCRIPTION
This feature adds an `outlet_at_confluence` flag which adjusts whether subwatersheds seed from the junction of upstream streams or one pixel up from that. Apparently both are useful. Doing this is a little tricky because you need to know in raster space what one pixel upstream on your arbitrary line is. I did this by adding `ds_x_1`, `ds_y_1` fields to the stream generator (the 1 means 1 pixel upstream) then I modified the subwatershed generator to use the upstream points on a stream as a segment starter if we're doing a confluence root or the `ds_x_1`, `ds_y_1` points if it's not.

I added a test to cover this functionality which is interesting by using non confluences you almost double the number of watersheds you have if you only ever join two streams. 

I didn't update history because this feature isn't released yet and the history note doesn't talk about the subfeatures in subwatershed generation.

I also added ONE BONUS bit of data which is an `outlet_x`/`outlet_y` field on the subwatersheds that give the raster x/y coordinates of the outlet. This is useful for sampling any raster that's aligned with these data at their outlets such as flow accumulation, DEM height, and maybe something else. It makes the class of flood filling algorithms a lot easier to implement because now we've got little discrete geometries that can be used to offset local hydrological fills.

Closes #165 