### PR TITLE
fixes #149 issue with empty vector on create raster from extents

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,9 @@ Release History
 
 Unreleased Changes
 ------------------
+* Fixed an issue in ``create_raster_from_vector_extents`` that would cause a
+  confusing exception to be raised if there was no geometry in the vector.
+  Now raises a ``ValueError`` with a helpful error message.
 * Changed parameters in ``convolve_2d`` to allow API to set
   ``ignore_nodata_and_edges=True`` while ``mask_nodata=False`` and updated
   docstring to indicate this is useful in cases such as filling nodata holes

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -976,6 +976,10 @@ def create_raster_from_vector_extents(
     Return:
         None
     """
+    if target_pixel_type not in _VALID_GDAL_TYPES:
+        raise ValueError(
+            f'Invalid target type, should be a gdal.GDT_* type, received '
+            f'"{target_pixel_type}"')
     # Determine the width and height of the tiff in pixels based on the
     # maximum size of the combined envelope of all the features
     vector = gdal.OpenEx(base_vector_path, gdal.OF_VECTOR)
@@ -1002,10 +1006,10 @@ def create_raster_from_vector_extents(
                 LOGGER.warning(error)
         layer = None
 
-    if target_pixel_type not in _VALID_GDAL_TYPES:
+    if shp_extent is None:
         raise ValueError(
-            'Invalid target type, should be a gdal.GDT_* type, received '
-            '"%s"' % target_pixel_type)
+            f'the vector at {base_vector_path} has no geometry, cannot '
+            f'create a raster from these extents')
 
     # round up on the rows and cols so that the target raster encloses the
     # base vector

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -986,24 +986,17 @@ def create_raster_from_vector_extents(
     shp_extent = None
     for layer_index in range(vector.GetLayerCount()):
         layer = vector.GetLayer(layer_index)
-        for feature in layer:
-            try:
-                # envelope is [xmin, xmax, ymin, ymax]
-                feature_extent = feature.GetGeometryRef().GetEnvelope()
-                if shp_extent is None:
-                    shp_extent = list(feature_extent)
-                else:
-                    # expand bounds of current bounding box to include that
-                    # of the newest feature
-                    shp_extent = [
-                        f(shp_extent[index], feature_extent[index])
-                        for index, f in enumerate([min, max, min, max])]
-            except AttributeError as error:
-                # For some valid OGR objects the geometry can be undefined
-                # since it's valid to have a NULL entry in the attribute table
-                # this is expressed as a None value in the geometry reference
-                # this feature won't contribute
-                LOGGER.warning(error)
+        if layer.GetFeatureCount() == 0:
+            continue
+        layer_extent = layer.GetExtent()
+        if shp_extent is None:
+            shp_extent = list(layer_extent)
+        else:
+            # expand bounds of current bounding box to include that
+            # of the newest feature
+            shp_extent = [
+                f(shp_extent[index], layer_extent[index])
+                for index, f in enumerate([min, max, min, max])]
         layer = None
 
     if shp_extent is None:

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1043,12 +1043,9 @@ def create_raster_from_vector_extents(
     if fill_value is not None:
         band = raster.GetRasterBand(1)
         band.Fill(fill_value)
-        band.FlushCache()
         band = None
-    layer = None
     vector = None
     raster = None
-    vector = None
 
 
 def interpolate_points(


### PR DESCRIPTION
This raises an issue if a vector is used to create a raster from its extents but it has no extents. Since I was in there I also simplified the extent checking to just the layers as well as a few other lines, moved the check for a valid raster type to the top, and simplified some raster reference management.

Updated history and added a test that @phargogh proposed in #149.

Fixes #149 