### PR TITLE
Bugfix/ignore where clause 172

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -57,8 +57,9 @@ Unreleased Changes
 * Added a ``max_pixel_fill_count`` parameter to ``routing.fill_pits`` to
   guard against pitfilling large natural depression. Defaults to 500.
 * Fixed an issue in ``align_and_resize_raster_stack`` that would ignore
-  the bounds of a feature in a mask vector if the ``"where"`` clause was
-  invoked and instead only considered the entire bounds of the vector.
+  the bounds of a feature in a mask vector if the
+  ``"mask_vector_where_filter"`` clause was invoked and instead only
+  considered the entire bounds of the vector.
 
 2.1.2 (2020-12-03)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -56,6 +56,9 @@ Unreleased Changes
   rather than "units per area".
 * Added a ``max_pixel_fill_count`` parameter to ``routing.fill_pits`` to
   guard against pitfilling large natural depression. Defaults to 500.
+* Fixed an issue in ``align_and_resize_raster_stack`` that would ignore
+  the bounds of a feature in a mask vector if the ``"where"`` clause was
+  invoked and instead only considered the entire bounds of the vector.
 
 2.1.2 (2020-12-03)
 ------------------

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -769,7 +769,10 @@ def align_and_resize_raster_stack(
                 [[feature.GetGeometryRef().GetEnvelope()[i]
                  for i in [0, 2, 1, 3]] for feature in mask_layer],
                 'union')
+            mask_layer = None
+            mask_vector = None
         else:
+            # if no where filter then use the raw vector bounding box
             mask_bounding_box = mask_vector_info['bounding_box']
 
         mask_vector_projection_wkt = mask_vector_info['projection_wkt']

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -776,8 +776,8 @@ def align_and_resize_raster_stack(
         if mask_vector_projection_wkt is not None and \
                 target_projection_wkt is not None:
             mask_vector_bb = transform_bounding_box(
-                mask_bounding_box,
-                mask_vector_info['projection_wkt'], target_projection_wkt)
+               mask_bounding_box, mask_vector_info['projection_wkt'],
+               target_projection_wkt)
         else:
             mask_vector_bb = mask_vector_info['bounding_box']
         # Calling `merge_bounding_box_list` will raise an ValueError if the

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -754,13 +754,29 @@ def align_and_resize_raster_stack(
             raise ValueError(
                 'vector_mask_options passed, but no value for '
                 '"mask_vector_path": %s', vector_mask_options)
+
         mask_vector_info = get_vector_info(
             vector_mask_options['mask_vector_path'])
+
+        if 'mask_vector_where_filter' in vector_mask_options:
+            # the bounding box only exists for the filtered features
+            mask_vector = gdal.OpenEx(
+                vector_mask_options['mask_vector_path'], gdal.OF_VECTOR)
+            mask_layer = mask_vector.GetLayer()
+            mask_layer.SetAttributeFilter(
+                vector_mask_options['mask_vector_where_filter'])
+            mask_bounding_box = merge_bounding_box_list(
+                [[feature.GetGeometryRef().GetEnvelope()[i]
+                 for i in [0, 2, 1, 3]] for feature in mask_layer],
+                'union')
+        else:
+            mask_bounding_box = mask_vector_info['bounding_box']
+
         mask_vector_projection_wkt = mask_vector_info['projection_wkt']
         if mask_vector_projection_wkt is not None and \
                 target_projection_wkt is not None:
             mask_vector_bb = transform_bounding_box(
-                mask_vector_info['bounding_box'],
+                mask_bounding_box,
                 mask_vector_info['projection_wkt'], target_projection_wkt)
         else:
             mask_vector_bb = mask_vector_info['bounding_box']

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -3477,17 +3477,18 @@ class TestGeoprocessing(unittest.TestCase):
 
         # make a vector whose bounding box is 1 degree  large
         poly_a = shapely.geometry.box(0, 0, 1, 1)
+        poly_b = shapely.geometry.box(-180, -90, 180, 90)
 
         poly_path = os.path.join(self.workspace_dir, 'poly.gpkg')
         _geometry_to_vector(
-            [poly_a], poly_path, fields={'value': ogr.OFTInteger},
-            attribute_list=[{'value': 100}],
+            [poly_a, poly_b], poly_path, fields={'value': ogr.OFTInteger},
+            attribute_list=[{'value': 100}, {'value': 1}],
             projection_epsg=4326)
 
         utm_31w_srs = osr.SpatialReference()
         utm_31w_srs.ImportFromEPSG(32631)
 
-        poly_bb = pygeoprocessing.get_vector_info(poly_path)['bounding_box']
+        poly_bb = [0, 0, 2, 2]
         poly_bb_transform = pygeoprocessing.transform_bounding_box(
             poly_bb, osr.SRS_WKT_WGS84_LAT_LONG,
             utm_31w_srs.ExportToWkt())
@@ -3503,6 +3504,7 @@ class TestGeoprocessing(unittest.TestCase):
             vector_mask_options={
                 'mask_vector_path': poly_path,
                 'mask_layer_name': 'poly',
+                'mask_vector_where_filter': 'value=100'
             })
 
         target_array = pygeoprocessing.raster_to_numpy_array(target_path)

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -15,7 +15,6 @@ from numpy.random import MT19937
 from numpy.random import RandomState
 from numpy.random import SeedSequence
 import numpy
-import numpy.testing
 import scipy.ndimage
 import shapely.geometry
 import shapely.wkt
@@ -3420,9 +3419,7 @@ class TestGeoprocessing(unittest.TestCase):
             _DEFAULT_ORIGIN[0] + 2*_DEFAULT_PIXEL_SIZE[0],
             _DEFAULT_ORIGIN[1] + 2*_DEFAULT_PIXEL_SIZE[1],
             _DEFAULT_ORIGIN[0] + 3*_DEFAULT_PIXEL_SIZE[0],
-            _DEFAULT_ORIGIN[1] + 3*_DEFAULT_PIXEL_SIZE[1],
-
-            )
+            _DEFAULT_ORIGIN[1] + 3*_DEFAULT_PIXEL_SIZE[1])
 
         dual_poly_path = os.path.join(self.workspace_dir, 'dual_poly.gpkg')
         _geometry_to_vector(
@@ -3463,7 +3460,6 @@ class TestGeoprocessing(unittest.TestCase):
         self.assertEqual(
             numpy.count_nonzero(target_array[target_array == 1]), 1)
 
-    #################
     def test_align_and_resize_raster_stack_int_with_vector_mask_bb(self):
         """PGP.geoprocessing: align/resize raster w/ vector mask."""
         os.makedirs(self.workspace_dir, exist_ok=True)

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -3420,7 +3420,9 @@ class TestGeoprocessing(unittest.TestCase):
             _DEFAULT_ORIGIN[0] + 2*_DEFAULT_PIXEL_SIZE[0],
             _DEFAULT_ORIGIN[1] + 2*_DEFAULT_PIXEL_SIZE[1],
             _DEFAULT_ORIGIN[0] + 3*_DEFAULT_PIXEL_SIZE[0],
-            _DEFAULT_ORIGIN[1] + 3*_DEFAULT_PIXEL_SIZE[1])
+            _DEFAULT_ORIGIN[1] + 3*_DEFAULT_PIXEL_SIZE[1],
+
+            )
 
         dual_poly_path = os.path.join(self.workspace_dir, 'dual_poly.gpkg')
         _geometry_to_vector(
@@ -3460,15 +3462,53 @@ class TestGeoprocessing(unittest.TestCase):
         # we should have only one pixel left
         self.assertEqual(
             numpy.count_nonzero(target_array[target_array == 1]), 1)
-        expected_bounding_box = [
-            _DEFAULT_ORIGIN[0] + 2*_DEFAULT_PIXEL_SIZE[0],
-            _DEFAULT_ORIGIN[1] + 2*_DEFAULT_PIXEL_SIZE[1],
-            _DEFAULT_ORIGIN[0] + 3*_DEFAULT_PIXEL_SIZE[0],
-            _DEFAULT_ORIGIN[1] + 3*_DEFAULT_PIXEL_SIZE[1]]
-        target_info = pygeoprocessing.get_raster_info(target_path)
-        numpy.testing.assert_allclose(
-            expected_bounding_box, target_info['bounding_box'])
 
+    #################
+    def test_align_and_resize_raster_stack_int_with_vector_mask_bb(self):
+        """PGP.geoprocessing: align/resize raster w/ vector mask."""
+        os.makedirs(self.workspace_dir, exist_ok=True)
+        pixel_a_matrix = numpy.ones((180, 360), numpy.int16)
+        target_nodata = -1
+        base_a_path = os.path.join(self.workspace_dir, 'base_a.tif')
+        _array_to_raster(
+            pixel_a_matrix, target_nodata, base_a_path,
+            pixel_size=(1, -1), projection_epsg=4326,
+            origin=(-180, 90))
+
+        # make a vector whose bounding box is 1 degree  large
+        poly_a = shapely.geometry.box(0, 0, 1, 1)
+
+        poly_path = os.path.join(self.workspace_dir, 'poly.gpkg')
+        _geometry_to_vector(
+            [poly_a], poly_path, fields={'value': ogr.OFTInteger},
+            attribute_list=[{'value': 100}],
+            projection_epsg=4326)
+
+        utm_31w_srs = osr.SpatialReference()
+        utm_31w_srs.ImportFromEPSG(32631)
+
+        poly_bb = pygeoprocessing.get_vector_info(poly_path)['bounding_box']
+        poly_bb_transform = pygeoprocessing.transform_bounding_box(
+            poly_bb, osr.SRS_WKT_WGS84_LAT_LONG,
+            utm_31w_srs.ExportToWkt())
+
+        target_path = os.path.join(self.workspace_dir, 'target_a.tif')
+
+        pygeoprocessing.align_and_resize_raster_stack(
+            [base_a_path], [target_path],
+            ['near'],
+            (111000/2, -111000/2), poly_bb_transform,
+            raster_align_index=0,
+            target_projection_wkt=utm_31w_srs.ExportToWkt(),
+            vector_mask_options={
+                'mask_vector_path': poly_path,
+                'mask_layer_name': 'poly',
+            })
+
+        target_array = pygeoprocessing.raster_to_numpy_array(target_path)
+        # chose half of 111km so that's 4 pixels in 1 degree
+        self.assertEqual(
+            numpy.count_nonzero(target_array[target_array == 1]), 4)
 
     def test_align_and_resize_raster_stack_int_with_bad_vector_mask(self):
         """PGP.geoprocessing: align/resize raster w/ bad vector mask."""

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -15,6 +15,7 @@ from numpy.random import MT19937
 from numpy.random import RandomState
 from numpy.random import SeedSequence
 import numpy
+import numpy.testing
 import scipy.ndimage
 import shapely.geometry
 import shapely.wkt
@@ -3459,6 +3460,15 @@ class TestGeoprocessing(unittest.TestCase):
         # we should have only one pixel left
         self.assertEqual(
             numpy.count_nonzero(target_array[target_array == 1]), 1)
+        expected_bounding_box = [
+            _DEFAULT_ORIGIN[0] + 2*_DEFAULT_PIXEL_SIZE[0],
+            _DEFAULT_ORIGIN[1] + 2*_DEFAULT_PIXEL_SIZE[1],
+            _DEFAULT_ORIGIN[0] + 3*_DEFAULT_PIXEL_SIZE[0],
+            _DEFAULT_ORIGIN[1] + 3*_DEFAULT_PIXEL_SIZE[1]]
+        target_info = pygeoprocessing.get_raster_info(target_path)
+        numpy.testing.assert_allclose(
+            expected_bounding_box, target_info['bounding_box'])
+
 
     def test_align_and_resize_raster_stack_int_with_bad_vector_mask(self):
         """PGP.geoprocessing: align/resize raster w/ bad vector mask."""


### PR DESCRIPTION
Fixes an issue that would cause a bounding box error when an "align and resize" was invoked on a global extents lat/lng raster but focused on a narrow bounding box and a local utm target projection. If a mask vector was also applied with a where filter to limit to a particular feature, align and resize would test the extents of the ENTIRE raster rather than just the where subset which would cause a bounding box alignment error. 

This PR detects if a where clause is used and builds a local bounding box that is only the bounding box of the features selected by the where clause. There is also a test added to cover this issue and an update to history.