### PR TITLE
add to convolve_2d docstring

### DIFF
--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2506,7 +2506,11 @@ def convolve_2d(
             values in these areas will be nonsensical numbers, perhaps
             numerical infinity or NaNs.
         normalize_kernel (boolean): If true, the result is divided by the
-            sum of the kernel.
+            sum of the kernel. If ``ignore_nodata_and_edges`` is also true,
+            this divides by the sum of the area of the kernel that is valid 
+            (not nodata or edge). For instance, a 3x3 kernel centered on a 
+            corner pixel would sum the 4 pixels that are within the raster 
+            and divide by 4.This combination is useful for averaging a raster.
         mask_nodata (boolean): If true, ``target_path`` raster's output is
             nodata where ``signal_path_band``'s pixels were nodata. Note that
             setting ``ignore_nodata_and_edges`` to ``True`` while setting

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2477,6 +2477,18 @@ def convolve_2d(
     Nodata values are treated as 0.0 during the convolution and masked to
     nodata for the output result where ``signal_path`` has nodata.
 
+    Note with default values, boundary effects can be seen in the result where
+    the kernel would hang off the edge of the raster or in regions with 
+    nodata pixels. The function would treat these areas as values with "0.0"
+    by default thus pulling the total convolution down in these areas. This
+    is similar to setting ``mode='same'`` in Numpy's ``convolve`` function:
+    https://numpy.org/doc/stable/reference/generated/numpy.convolve.html
+
+    This boundary effect can be avoided by setting 
+    ``ignore_nodata_and_edges=True`` which normalizes the target result by 
+    dynamically accounting for the number of valid signal pixels the kernel 
+    overlapped during the convolution step.
+
     Args:
         signal_path_band (tuple): a 2 tuple of the form
             (filepath to signal raster, band index).
@@ -2505,12 +2517,11 @@ def convolve_2d(
             over any areas except nodata holes, in this case the resulting
             values in these areas will be nonsensical numbers, perhaps
             numerical infinity or NaNs.
+                Setting this value to ``True`` is similar to the effect
+            created by setting ``mode`` to ``"valid"`` in Numpy's
+            convolve function: https://numpy.org/doc/stable/reference/generated/numpy.convolve.html
         normalize_kernel (boolean): If true, the result is divided by the
-            sum of the kernel. If ``ignore_nodata_and_edges`` is also true,
-            this divides by the sum of the area of the kernel that is valid 
-            (not nodata or edge). For instance, a 3x3 kernel centered on a 
-            corner pixel would sum the 4 pixels that are within the raster 
-            and divide by 4.This combination is useful for averaging a raster.
+            sum of the kernel.
         mask_nodata (boolean): If true, ``target_path`` raster's output is
             nodata where ``signal_path_band``'s pixels were nodata. Note that
             setting ``ignore_nodata_and_edges`` to ``True`` while setting

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1171,7 +1171,7 @@ def zonal_statistics(
             aggregation coverage close to optimally by rasterizing sets of
             polygons that don't overlap.  However, this step can be
             computationally expensive for cases where there are many polygons.
-            Setting this flag to False directs the function rasterize in one
+              this flag to False directs the function rasterize in one
             step.
         working_dir (string): If not None, indicates where temporary files
             should be created during this run.
@@ -2517,9 +2517,6 @@ def convolve_2d(
             over any areas except nodata holes, in this case the resulting
             values in these areas will be nonsensical numbers, perhaps
             numerical infinity or NaNs.
-                Setting this value to ``True`` is similar to the effect
-            created by setting ``mode`` to ``"valid"`` in Numpy's
-            convolve function: https://numpy.org/doc/stable/reference/generated/numpy.convolve.html
         normalize_kernel (boolean): If true, the result is divided by the
             sum of the kernel.
         mask_nodata (boolean): If true, ``target_path`` raster's output is


### PR DESCRIPTION
Expanding a docstring to clarify a feature that @phargogh and I were discussing yesterday. It wasn't apparent to me until I tried it out that it would ignore nodata and edges in the average, rather than dividing by the constant `kernel_sum`.