### PR TITLE
convolve_2d: assign a default nodata value as described in the docstring.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -60,6 +60,8 @@ Unreleased Changes
   the bounds of a feature in a mask vector if the
   ``"mask_vector_where_filter"`` clause was invoked and instead only
   considered the entire bounds of the vector.
+* Fixed an issue with ``convolve_2d`` that allowed output rasters to be
+  created without a defined nodata value.
 
 2.1.2 (2020-12-03)
 ------------------

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2553,6 +2553,8 @@ def convolve_2d(
             "`target_datatype` is set, but `target_nodata` is None. "
             "`target_nodata` must be set if `target_datatype` is not "
             "`gdal.GDT_Float64`.  `target_nodata` is set to None.")
+    if target_nodata is None:
+        target_nodata = float(numpy.finfo(numpy.float32).min)
 
     if ignore_nodata_and_edges and not mask_nodata:
         LOGGER.debug(
@@ -2773,10 +2775,7 @@ def convolve_2d(
             f"{os.path.basename(target_path)}")
 
     # set the nodata value from 0 to a reasonable value for the result
-    if target_nodata is None:
-        target_band.DeleteNoDataValue()
-    else:
-        target_band.SetNoDataValue(target_nodata)
+    target_band.SetNoDataValue(target_nodata)
 
     target_band = None
     target_raster = None

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -4166,8 +4166,9 @@ class TestGeoprocessing(unittest.TestCase):
         target_array = pygeoprocessing.raster_to_numpy_array(target_path)
         target_nodata = pygeoprocessing.get_raster_info(
             target_path)['nodata'][0]
+        self.assertIsNotNone(target_nodata)
 
-        expected_output = numpy.empty(signal_array.shape, numpy.float32)
+        expected_output = numpy.empty(signal_array.shape, numpy.float64)
         expected_output[:] = target_nodata
         expected_output[0, 0] = 1
         expected_output[-1, -1] = 1

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -4166,7 +4166,9 @@ class TestGeoprocessing(unittest.TestCase):
         target_array = pygeoprocessing.raster_to_numpy_array(target_path)
         target_nodata = pygeoprocessing.get_raster_info(
             target_path)['nodata'][0]
-        self.assertIsNotNone(target_nodata)
+        # target_nodata should be assigned this value when defaults are used
+        self.assertAlmostEqual(
+            target_nodata, float(numpy.finfo(numpy.float32).min))
 
         expected_output = numpy.empty(signal_array.shape, numpy.float64)
         expected_output[:] = target_nodata


### PR DESCRIPTION
This fixes #179 

If `target_nodata` is left as `None` we default to the minimum float32. This seemed like the intention all along based on the docstring.