### PR TITLE
Fix zonal_statistics logging bug

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -60,6 +60,7 @@ Unreleased Changes
   the bounds of a feature in a mask vector if the
   ``"mask_vector_where_filter"`` clause was invoked and instead only
   considered the entire bounds of the vector.
+* Fixed a LOGGER message bug that occurred in ``zonal_statistics``.
 
 2.1.2 (2020-12-03)
 ------------------

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1338,7 +1338,7 @@ def zonal_statistics(
             os.path.basename(aggregate_vector_path))
         rasterize_callback = _make_logger_callback(
             "rasterizing polygon " + str(set_index+1) + " of " +
-            str(len(disjoint_fid_set)) + " set %.1f%% complete")
+            str(len(disjoint_fid_set)) + " set %.1f%% complete %s")
         gdal.RasterizeLayer(
             agg_fid_raster, [1], disjoint_layer,
             callback=rasterize_callback, **rasterize_layer_args)


### PR DESCRIPTION
This PR adds a string placeholder for a LOGGER message callback in `zonal_statistics`. I tested this locally in a workflow where I was seeing this issue. It works as expected now.

Fixes #182 