### PR TITLE
Support Python 3.9

### DIFF
--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -8,13 +8,15 @@ jobs:
             fail-fast: false
             matrix:
                 os: [windows-latest, macos-latest]
-                python-version: [3.7, 3.8]
+                python-version: [3.7, 3.8, 3.9]
                 python-arch: [x86, x64]
                 include:
                     - python-version: 3.7
                       numpy: "numpy~=1.15"
                     - python-version: 3.8
                       numpy: "numpy~=1.17"
+                    - python-version: 3.9
+                      numpy: "numpy~=1.19"
 
                 exclude:
                     - os: macos-latest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,25 +31,7 @@ jobs:
       shell: bash -l {0}
       run: conda upgrade -y pip setuptools
 
-    - name: Install PyGeoprocessing (Windows)
-      if: matrix.os == 'windows-latest'
-      env:
-          PIP_EXTRA_INDEX_URL: "http://pypi.naturalcapitalproject.org/simple/"
-          PIP_TRUSTED_HOST: "pypi.naturalcapitalproject.org"
-          PIP_PREFER_BINARY: 1
-      shell: bash -l {0}
-      # Replace numpy and scipy with PyPI versions to circumvent import issue.
-      # https://stackoverflow.com/a/37110747/299084
-      #
-      # Shapely 1.7.0 on PyPI has GEOS cdll issues in some environments. Gohlke builds work.
-      run: |
-          conda install $PACKAGES
-          python -m pip install shapely --index-url http://pypi.naturalcapitalproject.org/simple/ -c requirements.txt
-          python -m pip install -r requirements.txt
-          python setup.py install
-
-    - name: Install PyGeoprocessing (Linux, Mac)
-      if: matrix.os != 'windows-latest'
+    - name: Install PyGeoprocessing
       shell: bash -l {0}
       run: |
           conda install --file requirements.txt

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,7 @@ Release History
 
 Unreleased Changes
 ------------------
+* Adding explicit support for Python 3.9 and testing on Python 3.9.
 * Fixed an issue in ``create_raster_from_vector_extents`` that would cause a
   confusing exception to be raised if there was no geometry in the vector.
   Now raises a ``ValueError`` with a helpful error message.


### PR DESCRIPTION
This PR verifies compatibility with Python 3.9, which we appear to get for free ... no real changes needed.

The only nontrivial change in this PR is the removal of the natcap PyPI, which was used for a time for GEOS builds that were compatible with the conda-forge GDAL builds (for some reason the conda-forge packages weren't compatible on Windows).  So the build process is a bit simpler as a result.

The question of which python versions are really needed for InVEST is still outstanding.