### PR TITLE
Bugfix/dist to channel no channels 171

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -64,6 +64,9 @@ Unreleased Changes
 * Fixed an issue with ``convolve_2d`` that allowed output rasters to be
   created without a defined nodata value.
 * Fixed a LOGGER message bug that occurred in ``zonal_statistics``.
+* Fixed an issue in ``distance_to_channel_mfd`` that would generate a raster
+  with distances to the edge of the raster even if there was no channel. Now
+  generates nodata so it is consistent with ``distance_to_channel_d8``.
 
 2.1.2 (2020-12-03)
 ------------------

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -2715,7 +2715,7 @@ def distance_to_channel_mfd(
                 if visited_managed_raster.get(xi_root, yi_root) == 0:
                     visited_managed_raster.set(xi_root, yi_root, 1)
                     distance_to_channel_stack.push(
-                        FlowPixelType(xi_root, yi_root, 0, -1))
+                        FlowPixelType(xi_root, yi_root, 0, distance_nodata))
 
                 while not distance_to_channel_stack.empty():
                     pixel = distance_to_channel_stack.top()
@@ -2752,7 +2752,7 @@ def distance_to_channel_mfd(
                             pixel.last_flow_dir = i_n
                             distance_to_channel_stack.push(pixel)
                             distance_to_channel_stack.push(
-                                FlowPixelType(xi_n, yi_n, 0, -1))
+                                FlowPixelType(xi_n, yi_n, 0, distance_nodata))
                             break
 
                         n_distance = distance_to_channel_managed_raster.get(
@@ -2774,7 +2774,7 @@ def distance_to_channel_mfd(
                         else:
                             weight_val = (SQRT2 if i_n % 2 else 1)
 
-                        if pixel.value == -1:
+                        if pixel.value == distance_nodata:
                             pixel.value = 0
                         pixel.value += flow_dir_weight * (
                             weight_val + n_distance)

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -2714,6 +2714,10 @@ def distance_to_channel_mfd(
 
                 if visited_managed_raster.get(xi_root, yi_root) == 0:
                     visited_managed_raster.set(xi_root, yi_root, 1)
+                    # arguments are x,y position of pixel, then last D8 flow
+                    # direction processed (0-7), and last is the running
+                    # accumulation distance accumulated by this pixel so far
+                    # initialized to nodata
                     distance_to_channel_stack.push(
                         FlowPixelType(xi_root, yi_root, 0, distance_nodata))
 

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -2799,6 +2799,7 @@ def distance_to_channel_mfd(
     flow_dir_mfd_managed_raster.close()
     if weight_raster is not None:
         weight_raster.close()
+    visited_managed_raster.close()
     shutil.rmtree(tmp_work_dir)
     LOGGER.info('%.1f%% complete', 100.0)
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1173,7 +1173,8 @@ class TestRouting(unittest.TestCase):
 
         flow_dir = numpy.ones((10, 10))
         streams = numpy.zeros((10, 10))
-        expected_result = numpy.full((10, 10), -1)
+        nodata = -1
+        expected_result = numpy.full((10, 10), nodata)
 
         flow_dir_path = os.path.join(
             self.workspace_dir, 'test_stream_distance_flow_dir.tif')
@@ -1182,10 +1183,10 @@ class TestRouting(unittest.TestCase):
         distance_path = os.path.join(
             self.workspace_dir, 'test_stream_distance_output.tif')
         pygeoprocessing.numpy_array_to_raster(
-            flow_dir, -1, (10, -10), (1000, 1000), projection_wkt,
+            flow_dir, nodata, (10, -10), (1000, 1000), projection_wkt,
             flow_dir_path)
         pygeoprocessing.numpy_array_to_raster(
-            streams, -1, (10, -10), (1000, 1000), projection_wkt,
+            streams, nodata, (10, -10), (1000, 1000), projection_wkt,
             streams_path)
 
         pygeoprocessing.routing.distance_to_channel_d8(


### PR DESCRIPTION
Fixed a bug in distance to channel MFD so that if the flow plain never reaches a channel the resulting distance raster is all nodata in that area, similar to D8 MFD.

This issue was caused by MFD tracking flows toward the channel, rather than channel up, but then not having a method to test if it never reached a channel. This was fixed by defaulting the distance to be nodata then tracking which cells have been visited in a separate raster rather than inferring it by a nodata value in the distance raster. 

Added a test case from @emlys in issue #171 to ensure correctness of this fix.