### PR TITLE
fixes #177 raises an exception if transform goes out of bounds

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -64,6 +64,10 @@ Unreleased Changes
 * Fixed an issue with ``convolve_2d`` that allowed output rasters to be
   created without a defined nodata value.
 * Fixed a LOGGER message bug that occurred in ``zonal_statistics``.
+* Added a check on ``transform_bounding_box`` to ensure the target bounding
+  box's coordinates were finite. This guards against cases where a transform
+  into another coordinate system creates a degenerate bounding box.
+  Previously the function would silently return non-finite coordinates.
 
 2.1.2 (2020-12-03)
 ------------------

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2973,6 +2973,11 @@ def transform_bounding_box(
     minx, maxx = sorted([raw_bounding_box[0], raw_bounding_box[2]])
     miny, maxy = sorted([raw_bounding_box[1], raw_bounding_box[3]])
     transformed_bounding_box = [minx, miny, maxx, maxy]
+    if not all(numpy.isfinite(numpy.array(transformed_bounding_box))):
+        raise ValueError(
+            f'some transformed coordinates are not finite: '
+            f'{transformed_bounding_box}, base bounding box may not fit into '
+            f'target coordinate projection system.')
     return transformed_bounding_box
 
 

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2922,6 +2922,11 @@ def transform_bounding_box(
         fitting bounding box around the original warped bounding box in
         ``new_epsg`` coordinate system.
 
+    Raises:
+        ``ValueError`` if resulting transform yields non-finite coordinates.
+        This would indicate an ill posed transform region that the user
+        should address.
+
     """
     base_ref = osr.SpatialReference()
     base_ref.ImportFromWkt(base_projection_wkt)

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2413,7 +2413,6 @@ class TestGeoprocessing(unittest.TestCase):
             result = pygeoprocessing.transform_bounding_box(
                 bounding_box_lat_lng_oob, osr.SRS_WKT_WGS84_LAT_LONG,
                 target_srs.ExportToWkt())
-            print(result)
         expected_message = "transformed coordinates are not finite"
         actual_message = str(cm.exception)
         self.assertTrue(expected_message in actual_message)

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2401,6 +2401,23 @@ class TestGeoprocessing(unittest.TestCase):
             numpy.testing.assert_allclose(
                 result, expected_result), None)
 
+    def test_transform_bounding_box_out_of_bounds(self):
+        """PGP.geoprocessing: test that bad transform raises an exception."""
+        # going to 91 degrees north to make an error
+        bounding_box_lat_lng_oob = [-45, 89, -43, 91]
+
+        target_srs = osr.SpatialReference()
+        target_srs.ImportFromEPSG(32619)  # UTM19N EPSG
+
+        with self.assertRaises(ValueError) as cm:
+            result = pygeoprocessing.transform_bounding_box(
+                bounding_box_lat_lng_oob, osr.SRS_WKT_WGS84_LAT_LONG,
+                target_srs.ExportToWkt())
+            print(result)
+        expected_message = "transformed coordinates are not finite"
+        actual_message = str(cm.exception)
+        self.assertTrue(expected_message in actual_message)
+
     def test_iterblocks(self):
         """PGP.geoprocessing: test iterblocks."""
         n_pixels = 100


### PR DESCRIPTION
This PR adds a check to `transform_bounding_box` to ensure that the result is finite. If not this raises a helpful exception. Added a test case to cover this feature and noting change in history.