### PR TITLE
fixes #168, valueerror if non-square blocksize on convolve 2d

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -64,6 +64,9 @@ Unreleased Changes
 * Fixed an issue with ``convolve_2d`` that allowed output rasters to be
   created without a defined nodata value.
 * Fixed a LOGGER message bug that occurred in ``zonal_statistics``.
+* The ``convolve_2d`` function now raises a ValueError if either the signal
+  or kernel raster has a row based blocksize since this could result in
+  very long runtimes due to gdal cache thrashing.
 
 2.1.2 (2020-12-03)
 ------------------

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -4244,7 +4244,6 @@ class TestGeoprocessing(unittest.TestCase):
         actual_message = str(cm.exception)
         self.assertTrue(expected_message in actual_message, actual_message)
 
-<<<<<<< HEAD
     def test_convolve_2d_non_square_blocksizes(self):
         """PGP.geo: test that convolve 2d errors on non-square blocksizes."""
         a_path = os.path.join(self.workspace_dir, 'a.tif')
@@ -4284,7 +4283,7 @@ class TestGeoprocessing(unittest.TestCase):
             expected_message = 'has a row blocksize'
             actual_message = str(cm.exception)
             self.assertTrue(expected_message in actual_message, actual_message)
-=======
+
     def test_convolve_with_byte_kernel(self):
         """PGP: test that byte kernel can still convolve."""
         array = numpy.ones((10, 10), dtype=numpy.float32)
@@ -4321,4 +4320,3 @@ class TestGeoprocessing(unittest.TestCase):
         numpy.testing.assert_almost_equal(
             pygeoprocessing.raster_to_numpy_array(int_out_path),
             array)
->>>>>>> main


### PR DESCRIPTION
This PR adds a check in convolve_2d that raises an exception with a helpful error message if the input rasters are in a row format. I also added a test case to cover this new functionality, and an update to the docstring and history.