### PR TITLE
fixes #161 extra long runtimes on large subwatersheds with large coordinates

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -64,11 +64,6 @@ Unreleased Changes
 * Fixed an issue with ``convolve_2d`` that allowed output rasters to be
   created without a defined nodata value.
 * Fixed a LOGGER message bug that occurred in ``zonal_statistics``.
-* Fixed an issue in ``calculate_subwatershed_boundary`` that would cause
-  excessive runtimes when calculating subwatershed boundaries in the case
-  where projected coordinates were large enough that numerical roundoff
-  error would cause the algorithm to be unable to determine when to quit
-  when drawing the boundary around the watershed area.
 
 2.1.2 (2020-12-03)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -64,6 +64,11 @@ Unreleased Changes
 * Fixed an issue with ``convolve_2d`` that allowed output rasters to be
   created without a defined nodata value.
 * Fixed a LOGGER message bug that occurred in ``zonal_statistics``.
+* Fixed an issue in ``calculate_subwatershed_boundary`` that would cause
+  excessive runtimes when calculating subwatershed boundaries in the case
+  where projected coordinates were large enough that numerical roundoff
+  error would cause the algorithm to be unable to determine when to quit
+  when drawing the boundary around the watershed area.
 
 2.1.2 (2020-12-03)
 ------------------

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -3907,7 +3907,7 @@ def calculate_subwatershed_boundary(
 
     cdef int x_l, y_l, outflow_dir
     cdef double x_f, y_f
-    cdef double x_first, y_first, x_p, y_p
+    cdef double x_p, y_p
     cdef long discovery, finish
 
     cdef time_t last_log_time = ctime(NULL)
@@ -3981,7 +3981,7 @@ def calculate_subwatershed_boundary(
 
     cdef int edge_side, edge_dir, cell_to_test, out_dir_increase=-1
     cdef int left, right, n_steps, terminated_early
-    cdef double abs_delta_x, abs_delta_y
+    cdef int delta_x, delta_y
     cdef int _int_max_steps_per_watershed = max_steps_per_watershed
 
     for index, (stream_fid, x_l, y_l) in enumerate(visit_order_stack):
@@ -4016,7 +4016,9 @@ def calculate_subwatershed_boundary(
         x_p, y_p = gdal.ApplyGeoTransform(geotransform, x_f, y_f)
         watershed_boundary.AddPoint(x_p, y_p)
 
-        x_first, y_first = x_p, y_p
+        # keep track of how many steps x/y and when we get back to 0 we've
+        # made a loop
+        delta_x, delta_y = 0, 0
 
         # determine the first edge
         if outflow_dir % 2 == 0:
@@ -4042,13 +4044,12 @@ def calculate_subwatershed_boundary(
 
         n_steps = 0
         terminated_early = 0
-        # deltas should be within 0.01 % of a pixel width
-        abs_delta_x = (abs(g1)+abs(g2)) * 0.01
-        abs_delta_y = (abs(g4)+abs(g5)) * 0.01
         while True:
             # step the edge then determine the projected coordinates
             x_f += D8_XOFFSET[edge_dir]
             y_f += D8_YOFFSET[edge_dir]
+            delta_x += D8_XOFFSET[edge_dir]
+            delta_y += D8_YOFFSET[edge_dir]
             # equivalent to gdal.ApplyGeoTransform(geotransform, x_f, y_f)
             # to eliminate python function call overhead
             x_p = g0 + g1*x_f + g2*y_f
@@ -4105,8 +4106,7 @@ def calculate_subwatershed_boundary(
                 edge_side = edge_dir
                 edge_dir = (edge_side + out_dir_increase) % 8
 
-            if _is_close(x_p, x_first, abs_delta_x, 0.0) and \
-                    _is_close(y_p, y_first, abs_delta_y, 0.0):
+            if delta_x == 0 and delta_y == 0:
                 # met the start point so we completed the watershed loop
                 break
 


### PR DESCRIPTION
This PR fixes #161 by tracking the integer delta of number of x/y steps taken when tracing a watershed's boundary rather than keeping track of the start and end point in projected coordinates. 

I didn't make a note in history since this feature wasn't released yet. I also haven't included a specific test case for this since it would requires a LARGE dataset and would require a runtime larger than all other tests combined in pygeoprocessing. 