### PR TITLE
Feature/force single drainage point 190

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -75,6 +75,11 @@ Unreleased Changes
   forces a DEM to only have one outlet at any point on the raster. The
   fill effect is that all pixels will drain to the raster coordinate at
   ``single_outlet_tuple``.
+* Added a ``detect_lowest_sink_and_drain`` function that finds the lowest
+  DEM pixel that drains to nodata/edge and the lowest DEM pixel that could
+  be a sink. The values that result from this call can be used to condition
+  a DEM that is known to have a single drain using the
+  ``single_outlet_tuple`` parameter in ``routing.fill_pits``.
 
 2.1.2 (2020-12-03)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -71,6 +71,10 @@ Unreleased Changes
   box's coordinates were finite. This guards against cases where a transform
   into another coordinate system creates a degenerate bounding box.
   Previously the function would silently return non-finite coordinates.
+* Added a ``single_outlet_tuple`` parameter to ``routing.fill_pits`` that
+  forces a DEM to only have one outlet at any point on the raster. The
+  fill effect is that all pixels will drain to the raster coordinate at
+  ``single_outlet_tuple``.
 
 2.1.2 (2020-12-03)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -80,6 +80,8 @@ Unreleased Changes
   be a sink. The values that result from this call can be used to condition
   a DEM that is known to have a single drain using the
   ``single_outlet_tuple`` parameter in ``routing.fill_pits``.
+* Fixed a bug in ``routing.fill_pits`` that could cause the nodata region of
+  a DEM to be incorrectly filled with non-nodata values.
 
 2.1.2 (2020-12-03)
 ------------------

--- a/src/pygeoprocessing/routing/__init__.py
+++ b/src/pygeoprocessing/routing/__init__.py
@@ -11,7 +11,7 @@ from pygeoprocessing.routing.routing import (
     detect_outlets,
     extract_strahler_streams_d8,
     calculate_subwatershed_boundary,
-    detect_lowest_sink_and_drain,
+    detect_lowest_drain_and_sink,
     )
 from pygeoprocessing.routing.watershed import (
     delineate_watersheds_d8)
@@ -30,5 +30,5 @@ __all__ = (
     'detect_outlets',
     'extract_strahler_streams_d8',
     'calculate_subwatershed_boundary',
-    'detect_lowest_sink_and_drain',
+    'detect_lowest_drain_and_sink',
 )

--- a/src/pygeoprocessing/routing/__init__.py
+++ b/src/pygeoprocessing/routing/__init__.py
@@ -11,6 +11,7 @@ from pygeoprocessing.routing.routing import (
     detect_outlets,
     extract_strahler_streams_d8,
     calculate_subwatershed_boundary,
+    detect_lowest_sink_and_drain,
     )
 from pygeoprocessing.routing.watershed import (
     delineate_watersheds_d8)
@@ -29,4 +30,5 @@ __all__ = (
     'detect_outlets',
     'extract_strahler_streams_d8',
     'calculate_subwatershed_boundary',
+    'detect_lowest_sink_and_drain',
 )

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -4245,7 +4245,7 @@ def detect_lowest_drain_and_sink(dem_raster_path_band):
         (drain_pixel, drain_height, sink_pixel, sink_height) -
             two (x, y) tuples with corresponding heights, first
             list is for edge drains, the second is for pit sinks. The x/y
-            coordinate is in raster coordinate space and `height` is the
+            coordinate is in raster coordinate space and ``height`` is the
             height of the given pixels in edge and pit respectively.
     """
     # this outer loop drives the raster block search

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -84,10 +84,6 @@ cdef int *D8_YOFFSET = [0, -1, -1, -1, 0, +1, +1, +1]
 # as a D8 direction
 cdef int* D8_REVERSE_DIRECTION = [4, 5, 6, 7, 0, 1, 2, 3]
 
-# default of number of pixels to naturally drain. This number was derived off
-# of reasonable expectations from a 30m DEM
-cdef int _MAX_PIXEL_FILL_COUNT = 500
-
 # exposing stl::priority_queue so we can have all 3 template arguments so
 # we can pass a different Compare functor
 cdef extern from "<queue>" namespace "std" nogil:
@@ -612,7 +608,7 @@ def _generate_read_bounds(offset_dict, raster_x_size, raster_y_size):
 def fill_pits(
         dem_raster_path_band, target_filled_dem_raster_path,
         working_dir=None,
-        long long max_pixel_fill_count=_MAX_PIXEL_FILL_COUNT,
+        long long max_pixel_fill_count=-1,
         single_outlet_tuple=None,
         raster_driver_creation_tuple=DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS):
     """Fill the pits in a DEM.

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -4192,7 +4192,7 @@ def calculate_subwatershed_boundary(
         '(calculate_subwatershed_boundary): watershed building 100% complete')
 
 
-def detect_lowest_sink_and_drain(dem_raster_path_band):
+def detect_lowest_drain_and_sink(dem_raster_path_band):
     """Find the lowest drain and sink pixel in the DEM.
 
     This function is used to specify conditions to DEMs that are known to
@@ -4211,15 +4211,15 @@ def detect_lowest_sink_and_drain(dem_raster_path_band):
 
         The result is two pixels indicating the first lowest edge and first
         lowest sink seen:
-            edge_pixel = (3, 4), 10
-            pit_pixel = (10, 15), 5
+            drain_pixel = (3, 4), 10
+            sink_pixel = (10, 15), 5
 
     Args:
         dem_raster_path_band (tuple): a raster/path band tuple to detect
             sinks in.
 
     Return:
-        (edge_pixel, edge_height, pit_pixel, pit_height) -
+        (drain_pixel, drain_height, sink_pixel, sink_height) -
             two (x, y) tuples with corresponding heights, first
             list is for edge drains, the second is for pit sinks. The x/y
             coordinate is in raster coordinate space and `height` is the
@@ -4227,10 +4227,10 @@ def detect_lowest_sink_and_drain(dem_raster_path_band):
     """
     # this outer loop drives the raster block search
     cdef double lowest_drain_height = numpy.inf
-    cdef double lowest_pit_height = numpy.inf
+    cdef double lowest_sink_height = numpy.inf
 
     drain_pixel = None
-    pit_pixel = None
+    sink_pixel = None
 
     dem_raster_info = pygeoprocessing.get_raster_info(
         dem_raster_path_band[0])
@@ -4277,7 +4277,7 @@ def detect_lowest_sink_and_drain(dem_raster_path_band):
                     continue
 
                 if (center_val > lowest_drain_height and
-                        center_val > lowest_pit_height):
+                        center_val > lowest_sink_height):
                     # already found something lower
                     continue
 
@@ -4309,12 +4309,12 @@ def detect_lowest_sink_and_drain(dem_raster_path_band):
                         # it'll drain downhill
                         pixel_drains = 1
                         break
-                if not pixel_drains and center_val < lowest_pit_height:
-                    lowest_pit_height = center_val
-                    pit_pixel = (xi_root, yi_root)
+                if not pixel_drains and center_val < lowest_sink_height:
+                    lowest_sink_height = center_val
+                    sink_pixel = (xi_root, yi_root)
     return (
         drain_pixel, lowest_drain_height,
-        pit_pixel, lowest_pit_height)
+        sink_pixel, lowest_sink_height)
 
 
 def detect_outlets(

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -4288,10 +4288,10 @@ def detect_lowest_drain_and_sink(dem_raster_path_band):
                 'pixels complete')
 
         # search block for local sinks
-        for yi in range(1, win_ysize+1):
-            yi_root = yi-1+yoff
-            for xi in range(1, win_xsize+1):
-                xi_root = xi-1+xoff
+        for yi in range(0, win_ysize):
+            yi_root = yi+yoff
+            for xi in range(0, win_xsize):
+                xi_root = xi+xoff
                 # this value is set in case it turns out to be the root of a
                 # pit, we'll start the fill from this pixel in the last phase
                 # of the algorithm

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -4245,7 +4245,7 @@ def detect_lowest_drain_and_sink(dem_raster_path_band):
         (drain_pixel, drain_height, sink_pixel, sink_height) -
             two (x, y) tuples with corresponding heights, first
             list is for edge drains, the second is for pit sinks. The x/y
-            coordinate is in raster coordinate space and ``height`` is the
+            coordinate is in raster coordinate space and _height is the
             height of the given pixels in edge and pit respectively.
     """
     # this outer loop drives the raster block search
@@ -4287,7 +4287,7 @@ def detect_lowest_drain_and_sink(dem_raster_path_band):
                 f'{current_pixel} of {raster_x_size * raster_y_size} '
                 'pixels complete')
 
-        # search block for locally undrained pixels
+        # search block for local sinks
         for yi in range(1, win_ysize+1):
             yi_root = yi-1+yoff
             for xi in range(1, win_xsize+1):

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -804,10 +804,10 @@ def fill_pits(
                 'pixels complete')
 
         # search block for locally undrained pixels
-        for yi in range(1, win_ysize+1):
-            yi_root = yi-1+yoff
-            for xi in range(1, win_xsize+1):
-                xi_root = xi-1+xoff
+        for yi in range(win_ysize):
+            yi_root = yi+yoff
+            for xi in range(win_xsize):
+                xi_root = xi+xoff
                 # this value is set in case it turns out to be the root of a
                 # pit, we'll start the fill from this pixel in the last phase
                 # of the algorithm
@@ -832,10 +832,6 @@ def fill_pits(
                     xi_n = xi_root+D8_XOFFSET[i_n]
                     yi_n = yi_root+D8_YOFFSET[i_n]
 
-                    if single_outlet:
-                        if (xi_n == outlet_x and yi_n == outlet_y):
-                            downhill_neighbor = 1
-                            break
                     if (xi_n < 0 or xi_n >= raster_x_size or
                             yi_n < 0 or yi_n >= raster_y_size):
                         if not single_outlet:
@@ -896,10 +892,6 @@ def fill_pits(
                                 natural_drain_exists = 1
                             continue
 
-                        if single_outlet:
-                            if xi_n == outlet_x and yi_n == outlet_y:
-                                natural_drain_exists = 1
-                                continue
                         n_height = filled_dem_managed_raster.get(
                             xi_n, yi_n)
                         if not single_outlet and _is_close(
@@ -970,20 +962,23 @@ def fill_pits(
                             else:
                                 continue
 
-                        if single_outlet:
-                            if xi_n == outlet_x and yi_n == outlet_y:
-                                pour_point = 1
-                                break
-
                         if pit_mask_managed_raster.get(
                                 xi_n, yi_n) == feature_id:
                             # this cell has already been processed
                             continue
-
                         # mark as visited in the search for pour point
                         pit_mask_managed_raster.set(xi_n, yi_n, feature_id)
 
                         n_height = filled_dem_managed_raster.get(xi_n, yi_n)
+                        if (single_outlet and xi_n == outlet_x
+                                and yi_n == outlet_y):
+                            LOGGER.debug(
+                                f'found single outlet pour point at '
+                                f'{xi_q} {yi_q} to {xi_n} {yi_n}')
+                            fill_height = n_height
+                            pour_point = 1
+                            break
+
                         if (not single_outlet and
                                 _is_close(n_height, dem_nodata, 1e-8, 1e-5)) \
                                 or (n_height < fill_height):

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -611,7 +611,8 @@ def _generate_read_bounds(offset_dict, raster_x_size, raster_y_size):
 
 def fill_pits(
         dem_raster_path_band, target_filled_dem_raster_path,
-        working_dir=None, long max_pixel_fill_count=_MAX_PIXEL_FILL_COUNT,
+        working_dir=None,
+        long long max_pixel_fill_count=_MAX_PIXEL_FILL_COUNT,
         single_outlet_tuple=None,
         raster_driver_creation_tuple=DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS):
     """Fill the pits in a DEM.
@@ -638,7 +639,8 @@ def fill_pits(
             call completes successfully.
         max_pixel_fill_count (int): maximum number of pixels to fill a pit
             before leaving as a depression. Useful if there are natural
-            large depressions.
+            large depressions. Value of -1 fills the raster with no search
+            limit.
         single_outlet_tuple (tuple): If not None, this is an x/y tuple in
             raster coordinates indicating the only pixel that can be
             considered a drain. If None then any pixel that would drain to
@@ -671,7 +673,7 @@ def fill_pits(
 
     # keep track of how many steps searched on the pit to test against
     # max_pixel_fill_count
-    cdef int search_steps
+    cdef long long search_steps
 
     # `search_queue` is used to grow a flat region searching for a pour point
     # to determine if region is plateau or, in the absence of a pour point,
@@ -879,7 +881,8 @@ def fill_pits(
                     xi_q = search_queue.front().xi
                     yi_q = search_queue.front().yi
                     search_queue.pop()
-                    if search_steps > max_pixel_fill_count:
+                    if (max_pixel_fill_count > 0 and
+                            search_steps > max_pixel_fill_count):
                         # clear the search queue and quit
                         while not search_queue.empty():
                             search_queue.pop()
@@ -947,7 +950,8 @@ def fill_pits(
                     yi_q = pixel.yi
 
                     # search to see if the fill has gone on too long
-                    if search_steps > max_pixel_fill_count:
+                    if (max_pixel_fill_count > 0 and
+                            search_steps > max_pixel_fill_count):
                         # clear pit_queue and quit
                         pit_queue = PitPriorityQueueType()
                         natural_drain_exists = 1

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -4292,9 +4292,6 @@ def detect_lowest_drain_and_sink(dem_raster_path_band):
             yi_root = yi+yoff
             for xi in range(0, win_xsize):
                 xi_root = xi+xoff
-                # this value is set in case it turns out to be the root of a
-                # pit, we'll start the fill from this pixel in the last phase
-                # of the algorithm
                 center_val = dem_managed_raster.get(xi_root, yi_root)
                 if _is_close(center_val, dem_nodata, 1e-8, 1e-5):
                     continue

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -701,7 +701,6 @@ def fill_pits(
     cdef int feature_id
 
     # used to handle the case for single outlet mode
-
     cdef int single_outlet=0, outlet_x=-1, outlet_y=-1
     if single_outlet_tuple is not None:
         single_outlet = 1

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -3106,10 +3106,7 @@ class TestGeoprocessing(unittest.TestCase):
         wgs84_ref = osr.SpatialReference()
         wgs84_ref.ImportFromEPSG(4326)  # WGS84 EPSG
 
-        workspace_dir = os.path.join('.', 'test_stitch_area')
-        os.makedirs(workspace_dir, exist_ok=True)
-
-        raster_a_path = os.path.join(workspace_dir, 'raster_a.tif')
+        raster_a_path = os.path.join(self.workspace_dir, 'raster_a.tif')
         raster_a_array = numpy.zeros((1, 1), dtype=numpy.int32)
         raster_a_array[:] = 1
 
@@ -3124,7 +3121,7 @@ class TestGeoprocessing(unittest.TestCase):
         # create a raster in wgs84 space that has a lot of pixel coverage
         # of the above raster
         target_stitch_path = os.path.join(
-            workspace_dir, 'stitch_by_area.tif')
+            self.workspace_dir, 'stitch_by_area.tif')
         pygeoprocessing.numpy_array_to_raster(
             numpy.full((1000, 1000), -1.0), -1, (0.0001, -0.0001), (1, 1),
             wgs84_ref.ExportToWkt(), target_stitch_path)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1198,7 +1198,7 @@ class TestRouting(unittest.TestCase):
             result_array = pygeoprocessing.raster_to_numpy_array(fill_path)
             numpy.testing.assert_almost_equal(result_array, expected_array)
 
-    def test_detect_lowest_sink_and_drain(self):
+    def test_detect_lowest_drain_and_sink(self):
         """PGP>routing: test detect_lowest_sink_and_drain."""
         dem_array = numpy.zeros((11, 11), dtype=numpy.float32)
         dem_array[3:8, 3:8] = -1.0
@@ -1208,16 +1208,16 @@ class TestRouting(unittest.TestCase):
         dem_path = os.path.join(self.workspace_dir, 'dem.tif')
         _array_to_raster(dem_array, None, dem_path)
 
-        edge_pixel, edge_height, pit_pixel, pit_height = \
-            pygeoprocessing.routing.detect_lowest_sink_and_drain(
+        drain_pixel, drain_height, sink_pixel, sink_height = \
+            pygeoprocessing.routing.detect_lowest_drain_and_sink(
                 (dem_path, 1))
 
-        expected_edge_pixel = (0, 0)
-        expected_edge_height = -1
-        expected_pit_pixel = (3, 3)
-        expected_pit_height = -1
+        expected_drain_pixel = (0, 0)
+        expected_drain_height = -1
+        expected_sink_pixel = (3, 3)
+        expected_sink_height = -1
 
-        self.assertEqual(edge_pixel, expected_edge_pixel)
-        self.assertEqual(edge_height, expected_edge_height)
-        self.assertEqual(pit_pixel, expected_pit_pixel)
-        self.assertEqual(pit_height, expected_pit_height)
+        self.assertEqual(drain_pixel, expected_drain_pixel)
+        self.assertEqual(drain_height, expected_drain_height)
+        self.assertEqual(sink_pixel, expected_sink_pixel)
+        self.assertEqual(sink_height, expected_sink_height)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1167,7 +1167,7 @@ class TestRouting(unittest.TestCase):
         dem_array = numpy.zeros((11, 11), dtype=numpy.float32)
         dem_array[0, 0] = -1.0
         dem_array[1:8, 1:8] = -2.0
-        dem_array[10, 7] = -4
+        dem_array[10, 7] = -4.0
         dem_array[8:11, 8:11] = 2.0
         dem_array[9:11, 9:11] = 1.0
         dem_array[10, 10] = -7.0

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1185,14 +1185,17 @@ class TestRouting(unittest.TestCase):
         expected_array_5_5[8:11, 8:11] = 2.0
         expected_array_5_5[10, 7] = 0
 
-        for output_tuple, expected_array in [
-                ((0, 0), expected_array_0_0),
-                ((5, 5), expected_array_5_5),
+        for output_tuple, expected_array, fill_dist in [
+                ((0, 0), expected_array_0_0, -1),
+                ((5, 5), expected_array_5_5, -1),
+                ((0, 0), dem_array, 0),
+                ((5, 5), dem_array, 0),
                 ]:
             fill_path = os.path.join(self.workspace_dir, 'filled.tif')
             pygeoprocessing.routing.fill_pits(
                 (dem_path, 1), fill_path,
                 single_outlet_tuple=output_tuple,
+                max_pixel_fill_count=fill_dist,
                 working_dir=self.workspace_dir)
             result_array = pygeoprocessing.raster_to_numpy_array(fill_path)
             numpy.testing.assert_almost_equal(result_array, expected_array)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1174,18 +1174,17 @@ class TestRouting(unittest.TestCase):
         dem_array[10, 10] = -7.0
         dem_path = os.path.join(self.workspace_dir, 'dem.tif')
         _array_to_raster(dem_array, None, dem_path)
-        _array_to_raster(dem_array, None, 'dem.tif')
 
         # outlet tuple at 0,0, just drain one edge
         expected_array_0_0 = numpy.copy(dem_array)
         expected_array_0_0[1:8, 1:8] = -1
         expected_array_0_0[10, 7] = 0
         expected_array_0_0[8:11, 8:11] = 2.0
-        _array_to_raster(expected_array_0_0, None, 'expected.tif')
 
         # output tuple at 5,5, it's a massive pit so drain the edges
         expected_array_5_5 = numpy.copy(dem_array)
-        expected_array_5_5[9:11, 9:11] = 0
+        expected_array_5_5[8:11, 8:11] = 2.0
+        expected_array_5_5[10, 7] = 0
 
         for output_tuple, expected_array in [
                 ((0, 0), expected_array_0_0),
@@ -1197,7 +1196,6 @@ class TestRouting(unittest.TestCase):
                 single_outlet_tuple=output_tuple,
                 working_dir=self.workspace_dir)
             result_array = pygeoprocessing.raster_to_numpy_array(fill_path)
-            _array_to_raster(result_array, None, 'filled.tif')
             numpy.testing.assert_almost_equal(result_array, expected_array)
 
     def test_detect_lowest_sink_and_drain(self):

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1188,8 +1188,8 @@ class TestRouting(unittest.TestCase):
         for output_tuple, expected_array, fill_dist in [
                 ((0, 0), expected_array_0_0, -1),
                 ((5, 5), expected_array_5_5, -1),
-                ((0, 0), dem_array, 0),
-                ((5, 5), dem_array, 0),
+                ((0, 0), dem_array, 1),
+                ((5, 5), dem_array, 1),
                 ]:
             fill_path = os.path.join(self.workspace_dir, 'filled.tif')
             pygeoprocessing.routing.fill_pits(
@@ -1198,7 +1198,8 @@ class TestRouting(unittest.TestCase):
                 max_pixel_fill_count=fill_dist,
                 working_dir=self.workspace_dir)
             result_array = pygeoprocessing.raster_to_numpy_array(fill_path)
-            numpy.testing.assert_almost_equal(result_array, expected_array)
+            numpy.testing.assert_almost_equal(
+                result_array, expected_array)
 
     def test_detect_lowest_drain_and_sink(self):
         """PGP.routing: test detect_lowest_sink_and_drain."""

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1198,7 +1198,7 @@ class TestRouting(unittest.TestCase):
             numpy.testing.assert_almost_equal(result_array, expected_array)
 
     def test_detect_lowest_drain_and_sink(self):
-        """PGP>routing: test detect_lowest_sink_and_drain."""
+        """PGP.routing: test detect_lowest_sink_and_drain."""
         dem_array = numpy.zeros((11, 11), dtype=numpy.float32)
         dem_array[3:8, 3:8] = -1.0
         dem_array[0, 0] = -1.0

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1168,18 +1168,24 @@ class TestRouting(unittest.TestCase):
         dem_array = numpy.zeros((11, 11), dtype=numpy.float32)
         dem_array[0, 0] = -1.0
         dem_array[1:8, 1:8] = -2.0
+        dem_array[10, 7] = -4
+        dem_array[8:11, 8:11] = 2.0
+        dem_array[9:11, 9:11] = 1.0
         dem_array[10, 10] = -7.0
         dem_path = os.path.join(self.workspace_dir, 'dem.tif')
         _array_to_raster(dem_array, None, dem_path)
+        _array_to_raster(dem_array, None, 'dem.tif')
 
         # outlet tuple at 0,0, just drain one edge
         expected_array_0_0 = numpy.copy(dem_array)
         expected_array_0_0[1:8, 1:8] = -1
-        expected_array_0_0[10, 10] = 0
+        expected_array_0_0[10, 7] = 0
+        expected_array_0_0[8:11, 8:11] = 2.0
+        _array_to_raster(expected_array_0_0, None, 'expected.tif')
 
         # output tuple at 5,5, it's a massive pit so drain the edges
         expected_array_5_5 = numpy.copy(dem_array)
-        expected_array_5_5[10, 10] = 0.0
+        expected_array_5_5[9:11, 9:11] = 0
 
         for output_tuple, expected_array in [
                 ((0, 0), expected_array_0_0),
@@ -1191,6 +1197,7 @@ class TestRouting(unittest.TestCase):
                 single_outlet_tuple=output_tuple,
                 working_dir=self.workspace_dir)
             result_array = pygeoprocessing.raster_to_numpy_array(fill_path)
+            _array_to_raster(result_array, None, 'filled.tif')
             numpy.testing.assert_almost_equal(result_array, expected_array)
 
     def test_detect_lowest_sink_and_drain(self):

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -42,9 +42,8 @@ class TestRouting(unittest.TestCase):
 
     def test_pit_filling_large_border(self):
         """PGP.routing: test pitfilling with large nodata border."""
-        workspace_dir = 'test_pit_filling_large_border'
-        os.makedirs(workspace_dir, exist_ok=True)
-        base_path = os.path.join(workspace_dir, 'base.tif')
+        os.makedirs(self.workspace_dir, exist_ok=True)
+        base_path = os.path.join(self.workspace_dir, 'base.tif')
         nodata = -1.0
         n = 30
         dem_array = numpy.full((n, n), nodata, dtype=numpy.float32)
@@ -56,13 +55,13 @@ class TestRouting(unittest.TestCase):
         dem_array[n//10+3:n//10-3+10, n//10+3:n//10-3+10] = 7
 
         _array_to_raster(dem_array, nodata, base_path)
-        fill_path = os.path.join(workspace_dir, 'filled.tif')
+        fill_path = os.path.join(self.workspace_dir, 'filled.tif')
         pygeoprocessing.routing.fill_pits(
-            (base_path, 1), fill_path, working_dir=workspace_dir)
+            (base_path, 1), fill_path, working_dir=self.workspace_dir)
         result_array = pygeoprocessing.raster_to_numpy_array(fill_path)
         expected_result = numpy.copy(dem_array)
         expected_result[n//10+2:n//10-2+10, n//10+2:n//10-2+10] = 8
-        expected_path = os.path.join(workspace_dir, 'expected.tif')
+        expected_path = os.path.join(self.workspace_dir, 'expected.tif')
         _array_to_raster(expected_result, nodata, expected_path)
         numpy.testing.assert_almost_equal(result_array, expected_result)
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -255,7 +255,6 @@ class TestRouting(unittest.TestCase):
         flow_dir_mfd[nodata_mask] = 0  # set to MFD nodata
         flow_dir_mfd_path = os.path.join(self.workspace_dir, 'mfd.tif')
         _array_to_raster(flow_dir_mfd, 0, flow_dir_mfd_path)
-        print(flow_dir_mfd)
         outlet_vector_path = os.path.join(
             self.workspace_dir, 'outlets.gpkg')
         pygeoprocessing.routing.detect_outlets(
@@ -1167,25 +1166,25 @@ class TestRouting(unittest.TestCase):
     def test_single_drain_point(self):
         """PGP.routing: test single_drain_point pitfill."""
         dem_array = numpy.zeros((11, 11), dtype=numpy.float32)
-        dem_array[3:8, 3:8] = -1.0
         dem_array[0, 0] = -1.0
-        dem_array[10, 10] = -1.0
+        dem_array[1:8, 1:8] = -2.0
+        dem_array[10, 10] = -7.0
         dem_path = os.path.join(self.workspace_dir, 'dem.tif')
         _array_to_raster(dem_array, None, dem_path)
 
         # outlet tuple at 0,0, just drain one edge
         expected_array_0_0 = numpy.copy(dem_array)
-        expected_array_0_0[3:8, 3:8] = 0.0
-        expected_array_0_0[10, 10] = 0.0
+        expected_array_0_0[1:8, 1:8] = -1
+        expected_array_0_0[10, 10] = 0
 
         # output tuple at 5,5, it's a massive pit so drain the edges
         expected_array_5_5 = numpy.copy(dem_array)
-        expected_array_5_5[0, 0] = 0.0
         expected_array_5_5[10, 10] = 0.0
 
         for output_tuple, expected_array in [
                 ((0, 0), expected_array_0_0),
-                ((5, 5), expected_array_5_5)]:
+                ((5, 5), expected_array_5_5),
+                ]:
             fill_path = os.path.join(self.workspace_dir, 'filled.tif')
             pygeoprocessing.routing.fill_pits(
                 (dem_path, 1), fill_path,
@@ -1215,6 +1214,5 @@ class TestRouting(unittest.TestCase):
 
         self.assertEqual(edge_pixel, expected_edge_pixel)
         self.assertEqual(edge_height, expected_edge_height)
-        print(pit_pixel)
         self.assertEqual(pit_pixel, expected_pit_pixel)
         self.assertEqual(pit_height, expected_pit_height)


### PR DESCRIPTION
This feature fixes #190 by adding a parameter to `fill_pits` called `single_outlet_tuple`. If present this forces the fill to treat that pixel as the only valid drain. Combined with another feature that `max_pixel_fill_count` can be set to -1 to fill non-stop this will force every non-nodata pixel in the raster to drain to the pixel targed in `single_outlet_tuple`. To help identify a candidate I've also added another function `detect_lowest_drain_and_sink` which returns the lowest edge drain and internal sink pixels that could be used in tandem with `single_outlet_tuple`. Here's all the changes:
* added new `single_outlet_tuple` parameter to `fill_pits`
* created new helper function `detect_lowest_drain_and_sink`
* fixed a bug in `fill_pits` that would have filled up the nodata region of a raster in a corner case
* added functionality that if `max_pixel_fill_count` is -1 it will not terminate early and set that to the default parameter for `fill_pits`
* added test cases to cover the above
* updated history describing the above