### PR TITLE
fixes #192, change to long, better logging, updated history

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -77,6 +77,8 @@ Unreleased Changes
   box's coordinates were finite. This guards against cases where a transform
   into another coordinate system creates a degenerate bounding box.
   Previously the function would silently return non-finite coordinates.
+* Fixing issue when calculating histogram for floating point rasters the
+  logging progress percent would be incorrectly calculated.
 
 2.1.2 (2020-12-03)
 ------------------

--- a/src/pygeoprocessing/geoprocessing_core.pyx
+++ b/src/pygeoprocessing/geoprocessing_core.pyx
@@ -869,7 +869,8 @@ def _raster_band_percentile_double(
     raster_info = pygeoprocessing.get_raster_info(
         base_raster_path_band[0])
     nodata = raster_info['nodata'][base_raster_path_band[1]-1]
-    cdef long long n_pixels = numpy.prod(raster_info['raster_size'])
+    cdef long long n_pixels = (
+        raster_info['raster_size'][0] * raster_info['raster_size'][1])
     cdef long long pixels_processed = 0
 
     last_update = time.time()

--- a/src/pygeoprocessing/geoprocessing_core.pyx
+++ b/src/pygeoprocessing/geoprocessing_core.pyx
@@ -734,7 +734,7 @@ def _raster_band_percentile_int(
         pixels_processed += block_data.size
         if time.time() - last_update > 5.0:
             LOGGER.debug(
-                f'data sort to heap {(100.*pixels_processed)/n_pixels}% '
+                f'data sort to heap {(100.*pixels_processed)/n_pixels:.1f}% '
                 f'complete, {pixels_processed} out of {n_pixels}'),
 
             last_update = time.time()
@@ -880,7 +880,7 @@ def _raster_band_percentile_double(
         pixels_processed += block_data.size
         if time.time() - last_update > 5.0:
             LOGGER.debug(
-                f'data sort to heap {(100.*pixels_processed)/n_pixels}% '
+                f'data sort to heap {(100.*pixels_processed)/n_pixels:.1f}% '
                 f'complete, {pixels_processed} out of {n_pixels}'),
 
             last_update = time.time()

--- a/src/pygeoprocessing/geoprocessing_core.pyx
+++ b/src/pygeoprocessing/geoprocessing_core.pyx
@@ -734,8 +734,9 @@ def _raster_band_percentile_int(
         pixels_processed += block_data.size
         if time.time() - last_update > 5.0:
             LOGGER.debug(
-                'data sort to heap %.2f%% complete',
-                (100.*pixels_processed)/n_pixels)
+                f'data sort to heap {(100.*pixels_processed)/n_pixels}% '
+                f'complete, {pixels_processed} out of {n_pixels}'),
+
             last_update = time.time()
         buffer_data = numpy.sort(
             block_data[~numpy.isclose(block_data, nodata)]).astype(
@@ -868,8 +869,8 @@ def _raster_band_percentile_double(
     raster_info = pygeoprocessing.get_raster_info(
         base_raster_path_band[0])
     nodata = raster_info['nodata'][base_raster_path_band[1]-1]
-    n_pixels = numpy.prod(raster_info['raster_size'])
-    pixels_processed = 0
+    cdef long long n_pixels = numpy.prod(raster_info['raster_size'])
+    cdef long long pixels_processed = 0
 
     last_update = time.time()
     LOGGER.debug('sorting data to heap')
@@ -878,8 +879,9 @@ def _raster_band_percentile_double(
         pixels_processed += block_data.size
         if time.time() - last_update > 5.0:
             LOGGER.debug(
-                'data sort to heap %.2f%% complete',
-                (100.*pixels_processed)/n_pixels)
+                f'data sort to heap {(100.*pixels_processed)/n_pixels}% '
+                f'complete, {pixels_processed} out of {n_pixels}'),
+
             last_update = time.time()
         buffer_data = numpy.sort(
             block_data[~numpy.isclose(block_data, nodata)]).astype(


### PR DESCRIPTION
Converted `pixels_processed` and `n_pixels` to 64 bit ints when processing floating point rasters. They were by default 32 bit ints before when they were not statically typed. Also made a more informative log message and updated history.