### PR TITLE
Fixes #207 -- undefined nodata exception in raster percentile

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 Release History
 ===============
 
+Unreleased Changes
+------------------
+* Fixed an issue with ``raster_band_percentile`` that would raise an
+  exception if an input raster had an undefined nodata value.
+
 2.3.0 (2021-06-21)
 ------------------
 * Added a ``single_outlet_tuple`` parameter to ``routing.fill_pits`` that

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,9 @@ Release History
 Unreleased Changes
 ------------------
 * Fixed an issue with ``raster_band_percentile`` that would raise an
-  exception if an input raster had an undefined nodata value.
+  exception if an input raster had an undefined nodata value and/or
+  would cause an invalid result if the raster contained non-finite
+  values.
 
 2.3.0 (2021-06-21)
 ------------------

--- a/src/pygeoprocessing/geoprocessing_core.pyx
+++ b/src/pygeoprocessing/geoprocessing_core.pyx
@@ -739,12 +739,11 @@ def _raster_band_percentile_int(
 
             last_update = time.time()
         if nodata is not None:
-            valid_mask = ~numpy.isclose(block_data, nodata)
+            clean_data = block_data[~numpy.isclose(block_data, nodata)]
         else:
-            valid_mask = numpy.ones(block_data.shape, dtype=bool)
-        valid_mask &= numpy.isfinite(block_data)
-        buffer_data = numpy.sort(
-            block_data[valid_mask]).astype(numpy.int64)
+            clean_data = block_data.flatten()
+        clean_data = clean_data[numpy.isfinite(clean_data)]
+        buffer_data = numpy.sort(clean_data).astype(numpy.int64)
         if buffer_data.size == 0:
             continue
         n_elements += buffer_data.size
@@ -889,12 +888,11 @@ def _raster_band_percentile_double(
 
             last_update = time.time()
         if nodata is not None:
-            valid_mask = ~numpy.isclose(block_data, nodata)
+            clean_data = block_data[~numpy.isclose(block_data, nodata)]
         else:
-            valid_mask = numpy.ones(block_data.shape, dtype=bool)
-        valid_mask &= numpy.isfinite(block_data)
-        buffer_data = numpy.sort(
-            block_data[valid_mask]).astype(numpy.double)
+            clean_data = block_data.flatten()
+        clean_data = clean_data[numpy.isfinite(clean_data)]
+        buffer_data = numpy.sort(clean_data).astype(numpy.double)
         if buffer_data.size == 0:
             continue
         n_elements += buffer_data.size

--- a/src/pygeoprocessing/geoprocessing_core.pyx
+++ b/src/pygeoprocessing/geoprocessing_core.pyx
@@ -738,9 +738,12 @@ def _raster_band_percentile_int(
                 f'complete, {pixels_processed} out of {n_pixels}'),
 
             last_update = time.time()
+        if nodata is not None:
+            valid_mask = ~numpy.isclose(block_data, nodata)
+        else:
+            valid_mask = numpy.ones(block_data.shape, dtype=bool)
         buffer_data = numpy.sort(
-            block_data[~numpy.isclose(block_data, nodata)]).astype(
-            numpy.int64)
+            block_data[valid_mask]).astype(numpy.int64)
         if buffer_data.size == 0:
             continue
         n_elements += buffer_data.size
@@ -884,9 +887,12 @@ def _raster_band_percentile_double(
                 f'complete, {pixels_processed} out of {n_pixels}'),
 
             last_update = time.time()
+        if nodata is not None:
+            valid_mask = ~numpy.isclose(block_data, nodata)
+        else:
+            valid_mask = numpy.ones(block_data.shape, dtype=bool)
         buffer_data = numpy.sort(
-            block_data[~numpy.isclose(block_data, nodata)]).astype(
-            numpy.double)
+            block_data[valid_mask]).astype(numpy.double)
         if buffer_data.size == 0:
             continue
         n_elements += buffer_data.size

--- a/src/pygeoprocessing/geoprocessing_core.pyx
+++ b/src/pygeoprocessing/geoprocessing_core.pyx
@@ -742,6 +742,7 @@ def _raster_band_percentile_int(
             valid_mask = ~numpy.isclose(block_data, nodata)
         else:
             valid_mask = numpy.ones(block_data.shape, dtype=bool)
+        valid_mask &= numpy.isfinite(block_data)
         buffer_data = numpy.sort(
             block_data[valid_mask]).astype(numpy.int64)
         if buffer_data.size == 0:
@@ -891,6 +892,7 @@ def _raster_band_percentile_double(
             valid_mask = ~numpy.isclose(block_data, nodata)
         else:
             valid_mask = numpy.ones(block_data.shape, dtype=bool)
+        valid_mask &= numpy.isfinite(block_data)
         buffer_data = numpy.sort(
             block_data[valid_mask]).astype(numpy.double)
         if buffer_data.size == 0:

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -3676,8 +3676,8 @@ class TestGeoprocessing(unittest.TestCase):
         actual_message = str(cm.exception)
         self.assertTrue(expected_message in actual_message, actual_message)
 
-    def test_percentile_long_type(self):
-        """PGP: test percentile with long type."""
+    def test_percentile_int_type(self):
+        """PGP: test percentile with int type."""
         srs = osr.SpatialReference()
         srs.ImportFromEPSG(4326)
         int_raster_path = os.path.join(self.workspace_dir, 'int_raster.tif')
@@ -3776,13 +3776,13 @@ class TestGeoprocessing(unittest.TestCase):
             "Expected only one file in the workspace directory after "
             "the call")
 
-    def test_percentile_long_type_undefined_nodata(self):
-        """PGP: test percentile with long type with undefined nodata."""
+    def test_percentile_int_type_undefined_nodata(self):
+        """PGP: test percentile with int type with undefined nodata."""
         srs = osr.SpatialReference()
         srs.ImportFromEPSG(4326)
         int_raster_path = os.path.join(self.workspace_dir, 'int_raster.tif')
         n_length = 10
-        # I made this array from a random set and since it's 100 elements long
+        # I made this array from a random set and since it's 100 elements int
         # I know exactly the percentile cutoffs.
         array = numpy.array([
             0, 153829, 346236, 359534, 372568, 432350, 468065, 620239,

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -3723,7 +3723,7 @@ class TestGeoprocessing(unittest.TestCase):
         srs.ImportFromEPSG(4326)
         percentile_cutoffs = [0.0, 22.5, 72.1, 99.0, 100.0]
         array = numpy.array([
-            -1, 0.012483605193988612, 0.015538926080136628,
+            numpy.nan, -1, 0.015538926080136628,
             0.0349541783138948, 0.056811563936455145, 0.06472245939357957,
             0.06763766500876733, 0.0996146617328485, 0.10319174490493743,
             0.1108529662149651, 0.11748524088704182, 0.13932099810203546,
@@ -3764,7 +3764,7 @@ class TestGeoprocessing(unittest.TestCase):
             array.reshape((n_length, n_length)), -1, double_raster_path)
 
         expected_float_percentiles = [
-            array[1], array[24], array[73], array[99]]
+            array[2], array[25], array[73], array[99]]
         actual_percentiles = pygeoprocessing.raster_band_percentile(
             (double_raster_path, 1), self.workspace_dir, percentile_cutoffs,
             heap_buffer_size=0)

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -3764,7 +3764,108 @@ class TestGeoprocessing(unittest.TestCase):
             array.reshape((n_length, n_length)), -1, double_raster_path)
 
         expected_float_percentiles = [
-            array[1], array[24], array[73], array[99], array[99]]
+            array[1], array[24], array[73], array[99]]
+        actual_percentiles = pygeoprocessing.raster_band_percentile(
+            (double_raster_path, 1), self.workspace_dir, percentile_cutoffs,
+            heap_buffer_size=0)
+        numpy.testing.assert_almost_equal(
+            actual_percentiles, expected_float_percentiles)
+        # ensure heapfiles were removed
+        self.assertEqual(
+            len([path for path in os.listdir(self.workspace_dir)]), 1,
+            "Expected only one file in the workspace directory after "
+            "the call")
+
+    def test_percentile_long_type_undefined_nodata(self):
+        """PGP: test percentile with long type with undefined nodata."""
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(4326)
+        int_raster_path = os.path.join(self.workspace_dir, 'int_raster.tif')
+        n_length = 10
+        # I made this array from a random set and since it's 100 elements long
+        # I know exactly the percentile cutoffs.
+        array = numpy.array([
+            0, 153829, 346236, 359534, 372568, 432350, 468065, 620239,
+            757710, 835119, 870788, 880695, 899211, 939183, 949597, 976023,
+            1210404, 1242155, 1395436, 1484104, 1563806, 1787749, 2001579,
+            2015145, 2080141, 2107594, 2331278, 2335667, 2508967, 2513463,
+            2529240, 2764320, 2782388, 2892567, 3131013, 3242402, 3313283,
+            3353958, 3427341, 3473886, 3507842, 3552610, 3730904, 3800470,
+            3871533, 3955725, 4114781, 4326231, 4333170, 4464510, 4585432,
+            4632068, 4671364, 4770370, 4927815, 4962157, 4974890, 5153019,
+            5370756, 5592526, 5611672, 5688083, 5746114, 5833862, 5890515,
+            5948526, 6030964, 6099825, 6162147, 6169317, 6181528, 6186133,
+            6225623, 6732204, 6800472, 7059916, 7097505, 7112239, 7435668,
+            7438680, 7713058, 7759246, 7878338, 7882983, 7974409, 8223956,
+            8226559, 8355570, 8433741, 8523959, 8853540, 8999076, 9109444,
+            9250199, 9262560, 9365311, 9404229, 9529068, 9597598,
+            2**31], dtype=numpy.uint32)
+        _array_to_raster(
+            array.reshape((n_length, n_length)), None, int_raster_path)
+
+        percentile_cutoffs = [0.0, 22.5, 72.1, 99.0, 100.0]
+        # manually rounding up the percentiles
+        expected_int_percentiles = [
+            array[0], array[23], array[73], array[99], array[99]]
+
+        working_dir = os.path.join(
+            self.workspace_dir, 'percentile_working_dir')
+        actual_int_percentiles = pygeoprocessing.raster_band_percentile(
+            (int_raster_path, 1), working_dir, percentile_cutoffs,
+            heap_buffer_size=8, ffi_buffer_size=4)
+        numpy.testing.assert_almost_equal(
+            actual_int_percentiles, expected_int_percentiles)
+        self.assertTrue(
+            not os.path.exists(working_dir), 'working dir was not deleted')
+
+    def test_percentile_double_type_undefined_nodata(self):
+        """PGP: test percentile function with double and undefined nodata."""
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(4326)
+        percentile_cutoffs = [0.0, 22.5, 72.1, 99.0, 100.0]
+        array = numpy.array([
+            0.0032453543, 0.012483605193988612, 0.015538926080136628,
+            0.0349541783138948, 0.056811563936455145, 0.06472245939357957,
+            0.06763766500876733, 0.0996146617328485, 0.10319174490493743,
+            0.1108529662149651, 0.11748524088704182, 0.13932099810203546,
+            0.14593634331220395, 0.17290496444623904, 0.18410163405268687,
+            0.19228618118906593, 0.19472498766411306, 0.19600894348473485,
+            0.19675234705931377, 0.22294217186343712, 0.24301516135472034,
+            0.25174824011708297, 0.25961212269403156, 0.2633977735981743,
+            0.26432729041437664, 0.26786682579209775, 0.29237261233784806,
+            0.29255695849184316, 0.2964090298109583, 0.2990174003705779,
+            0.30405728527347686, 0.3264688470028486, 0.33514871371769506,
+            0.3482838254608601, 0.35647966026887656, 0.3610103066480047,
+            0.36266883466382505, 0.3722525921166677, 0.3732773924434396,
+            0.37359492466545774, 0.3782442911035093, 0.38183103184230927,
+            0.4061775627324341, 0.40752141481722104, 0.42563138319552407,
+            0.45240943914984344, 0.48131663894772847, 0.48452027730035463,
+            0.5080370178708488, 0.5160581721673511, 0.5207327746991738,
+            0.5218827923543758, 0.5254400558377796, 0.5314284222888134,
+            0.5399960806407419, 0.5540251419037007, 0.567883875779636,
+            0.5759479782760882, 0.5762026663686868, 0.5851386281066929,
+            0.6023424727834, 0.6224012318616832, 0.6349951577963391,
+            0.6352127038584446, 0.6361159542649262, 0.6369708440504545,
+            0.6432382687009855, 0.6449485473328685, 0.6458541196589433,
+            0.6638401540497775, 0.6810857637187034, 0.6914374635530586,
+            0.7146862236370655, 0.7335122551062899, 0.7380305619344611,
+            0.7481552829167317, 0.7534333422153502, 0.7659278079221241,
+            0.7802925160056647, 0.7840515443802779, 0.7858175566560684,
+            0.7882952522603599, 0.7931210734787487, 0.8054471062280362,
+            0.8369260071883123, 0.8448121201845042, 0.8457743106122408,
+            0.8725394176743159, 0.8776084968191854, 0.8932892524100567,
+            0.8974703081229631, 0.9246294314690737, 0.9470450112295367,
+            0.9497456418201979, 0.9599420128556164, 0.9777130042139013,
+            0.9913972371243881, 0.9930411737585775, 0.9963741185277734,
+            0.9971933068336024], dtype=numpy.float32)
+        double_raster_path = os.path.join(
+            self.workspace_dir, 'double_raster.tif')
+        n_length = 10
+        _array_to_raster(
+            array.reshape((n_length, n_length)), None, double_raster_path)
+
+        expected_float_percentiles = [
+            array[0], array[23], array[73], array[99], array[99]]
         actual_percentiles = pygeoprocessing.raster_band_percentile(
             (double_raster_path, 1), self.workspace_dir, percentile_cutoffs,
             heap_buffer_size=0)

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -3685,7 +3685,7 @@ class TestGeoprocessing(unittest.TestCase):
         # I made this array from a random set and since it's 100 elements long
         # I know exactly the percentile cutoffs.
         array = numpy.array([
-            1975, 153829, 346236, 359534, 372568, 432350, 468065, 620239,
+            0, 153829, 346236, 359534, 372568, 432350, 468065, 620239,
             757710, 835119, 870788, 880695, 899211, 939183, 949597, 976023,
             1210404, 1242155, 1395436, 1484104, 1563806, 1787749, 2001579,
             2015145, 2080141, 2107594, 2331278, 2335667, 2508967, 2513463,
@@ -3701,12 +3701,12 @@ class TestGeoprocessing(unittest.TestCase):
             9250199, 9262560, 9365311, 9404229, 9529068, 9597598,
             2**31], dtype=numpy.uint32)
         _array_to_raster(
-            array.reshape((n_length, n_length)), -1, int_raster_path)
+            array.reshape((n_length, n_length)), 0, int_raster_path)
 
         percentile_cutoffs = [0.0, 22.5, 72.1, 99.0, 100.0]
         # manually rounding up the percentiles
         expected_int_percentiles = [
-            array[0], array[23], array[73], array[99], array[99]]
+            array[1], array[24], array[73], array[99]]
         working_dir = os.path.join(
             self.workspace_dir, 'percentile_working_dir')
         actual_int_percentiles = pygeoprocessing.raster_band_percentile(
@@ -3723,7 +3723,7 @@ class TestGeoprocessing(unittest.TestCase):
         srs.ImportFromEPSG(4326)
         percentile_cutoffs = [0.0, 22.5, 72.1, 99.0, 100.0]
         array = numpy.array([
-            0.003998113607125986, 0.012483605193988612, 0.015538926080136628,
+            -1, 0.012483605193988612, 0.015538926080136628,
             0.0349541783138948, 0.056811563936455145, 0.06472245939357957,
             0.06763766500876733, 0.0996146617328485, 0.10319174490493743,
             0.1108529662149651, 0.11748524088704182, 0.13932099810203546,
@@ -3764,7 +3764,7 @@ class TestGeoprocessing(unittest.TestCase):
             array.reshape((n_length, n_length)), -1, double_raster_path)
 
         expected_float_percentiles = [
-            array[0], array[23], array[73], array[99], array[99]]
+            array[1], array[24], array[73], array[99], array[99]]
         actual_percentiles = pygeoprocessing.raster_band_percentile(
             (double_raster_path, 1), self.workspace_dir, percentile_cutoffs,
             heap_buffer_size=0)


### PR DESCRIPTION
This PR adds tests for a case where raster nodata values are undefined on raster percentile. I also updated the tests for valid nodata to ensure that the nodata value was *not* being used as part of the percentile calculation. Also updated history.