### PR TITLE
Allow nodata reclassification

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 Release History
 ===============
 
+Unreleased
+----------
+* Restore functionality in ``reclassify_raster`` that allows for nodata
+  values to be reclassified. This was accidentally removed in 2.3.1.
+
 2.3.1 (2021-08-24)
 ------------------
 * Slightly change the error message displayed for a

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1837,8 +1837,6 @@ def reclassify_raster(
     """
     if len(value_map) == 0:
         raise ValueError("value_map must contain at least one value")
-    if target_nodata is None:
-        raise ValueError("target_nodata must be a valid number, received None")
     if not _is_raster_path_band_formatted(base_raster_path_band):
         raise ValueError(
             "Expected a (path, band_id) tuple, instead got '%s'" %
@@ -1856,6 +1854,14 @@ def reclassify_raster(
                 nodata_dest_value = val
                 del value_map_copy[key]
                 break
+
+    if target_nodata is None and nodata_dest_value is None:
+        raise ValueError(
+            "target_nodata was set to None and the base raster nodata"
+            " value was not represented in the value_map. reclassify_raster"
+            " does not assume the base raster nodata value should be used"
+            " as the target_nodata value. Set target_nodata to a valid number"
+            " and/or add a base raster nodata value mapping to value_map.")
 
     keys = sorted(numpy.array(list(value_map_copy.keys())))
     values = numpy.array([value_map_copy[x] for x in keys])

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1850,6 +1850,7 @@ def reclassify_raster(
             if numpy.isclose(key, nodata):
                 nodata_dest_value = val
                 del value_map_copy[key]
+                break
 
     keys = sorted(numpy.array(list(value_map_copy.keys())))
     values = numpy.array([value_map_copy[x] for x in keys])

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1798,8 +1798,10 @@ def reclassify_raster(
     """Reclassify pixel values in a raster.
 
     A function to reclassify values in raster to any output type. By default
-    the values except for nodata must be in ``value_map``. If nodata is
-    present in ``value_map`` nodata values are reclassified.
+    the values except for nodata must be in ``value_map``. If the base
+    raster nodata value is in ``value_map``, then nodata values are
+    reclassified to the mapped value. This would essentially leave no nodata
+    holes in the target raster.
 
     Args:
         base_raster_path_band (tuple): a tuple including file path to a raster

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1834,6 +1834,8 @@ def reclassify_raster(
     """
     if len(value_map) == 0:
         raise ValueError("value_map must contain at least one value")
+    if target_nodata is None:
+        raise ValueError("target_nodata must be a valid number, received None")
     if not _is_raster_path_band_formatted(base_raster_path_band):
         raise ValueError(
             "Expected a (path, band_id) tuple, instead got '%s'" %

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1798,10 +1798,9 @@ def reclassify_raster(
     """Reclassify pixel values in a raster.
 
     A function to reclassify values in raster to any output type. By default
-    the values except for nodata must be in ``value_map``. If the base
-    raster nodata value is in ``value_map``, then nodata values are
-    reclassified to the mapped value. This would essentially leave no nodata
-    holes in the target raster.
+    the values except for nodata must be in ``value_map``. Include the
+    base raster nodata value in ``value_map`` to reclassify nodata pixels
+    to a valid value.
 
     Args:
         base_raster_path_band (tuple): a tuple including file path to a raster
@@ -1816,7 +1815,9 @@ def reclassify_raster(
             it exists
         target_datatype (gdal type): the numerical type for the target raster
         target_nodata (numerical type): the nodata value for the target raster.
-            Must be the same type as target_datatype
+            Must be the same type as target_datatype. All nodata pixels in
+            the base raster will be reclassified to this value, unless the
+            base raster notata values are present in ``value_map``.
         values_required (bool): If True, raise a ValueError if there is a
             value in the raster that is not found in ``value_map``.
         raster_driver_creation_tuple (tuple): a tuple containing a GDAL driver

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -281,6 +281,30 @@ class TestGeoprocessing(unittest.TestCase):
         self.assertAlmostEqual(numpy.sum(target_array), 2)
         self.assertAlmostEqual(target_info['nodata'][0], target_nodata)
 
+    def test_reclassify_raster_reclass_new_nodata(self):
+        """PGP.geoprocessing: test reclassifying None nodata value."""
+        n_pixels = 9
+        pixel_matrix = numpy.array([[0, 1, -1]], dtype=numpy.int16)
+        nodata = 0
+        raster_path = os.path.join(self.workspace_dir, 'raster.tif')
+        target_path = os.path.join(self.workspace_dir, 'target.tif')
+        _array_to_raster(pixel_matrix, nodata, raster_path)
+
+        value_map = {
+            1: 5,
+            -1: 6,
+        }
+        target_nodata = 10
+
+        pygeoprocessing.reclassify_raster(
+            (raster_path, 1), value_map, target_path, gdal.GDT_Int16,
+            target_nodata, values_required=True)
+        target_info = pygeoprocessing.get_raster_info(target_path)
+        target_array = pygeoprocessing.raster_to_numpy_array(target_path)
+        expected = numpy.array([[10, 5, 6]])
+        numpy.testing.assert_allclose(target_array, expected)
+        self.assertAlmostEqual(target_info['nodata'][0], target_nodata)
+
     def test_reclassify_raster_reclass_nodata_none(self):
         """PGP.geoprocessing: test reclassifying None nodata value."""
         n_pixels = 9

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -249,8 +249,10 @@ class TestGeoprocessing(unittest.TestCase):
         pygeoprocessing.reclassify_raster(
             (raster_path, 1), value_map, target_path, gdal.GDT_Float32,
             target_nodata, values_required=True)
+        target_info = pygeoprocessing.get_raster_info(target_path)
         target_array = pygeoprocessing.raster_to_numpy_array(target_path)
         self.assertAlmostEqual(numpy.sum(target_array), 2)
+        self.assertAlmostEqual(target_info['nodata'][0], target_nodata)
 
     def test_reclassify_raster_reclass_max_nodata(self):
         """PGP.geoprocessing: test reclassifying max nodata value."""
@@ -274,8 +276,37 @@ class TestGeoprocessing(unittest.TestCase):
         pygeoprocessing.reclassify_raster(
             (raster_path, 1), value_map, target_path, gdal.GDT_Float32,
             target_nodata, values_required=True)
+        target_info = pygeoprocessing.get_raster_info(target_path)
         target_array = pygeoprocessing.raster_to_numpy_array(target_path)
         self.assertAlmostEqual(numpy.sum(target_array), 2)
+        self.assertAlmostEqual(target_info['nodata'][0], target_nodata)
+
+    def test_reclassify_raster_reclass_nodata_none(self):
+        """PGP.geoprocessing: test reclassifying None nodata value."""
+        n_pixels = 9
+        pixel_matrix = numpy.ones((n_pixels, n_pixels), numpy.float32)
+        test_value = 0.5
+        pixel_matrix[:] = test_value
+        nodata = -1
+        pixel_matrix[0,0] = nodata
+        pixel_matrix[5,7] = nodata
+        raster_path = os.path.join(self.workspace_dir, 'raster.tif')
+        target_path = os.path.join(self.workspace_dir, 'target.tif')
+        _array_to_raster(
+            pixel_matrix, nodata, raster_path)
+
+        value_map = {
+            test_value: 0,
+            nodata: 1,
+        }
+        target_nodata = None
+        with self.assertRaises(ValueError) as cm:
+            pygeoprocessing.reclassify_raster(
+                (raster_path, 1), value_map, target_path, gdal.GDT_Float32,
+                target_nodata, values_required=True)
+        expected_message = 'target_nodata must be a valid number'
+        actual_message = str(cm.exception)
+        self.assertTrue(expected_message in actual_message, actual_message)
 
     def test_reproject_vector(self):
         """PGP.geoprocessing: test reproject vector."""

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -227,6 +227,56 @@ class TestGeoprocessing(unittest.TestCase):
         actual = pygeoprocessing.raster_to_numpy_array(target_path)
         numpy.testing.assert_allclose(actual, expected)
 
+    def test_reclassify_raster_reclass_nodata(self):
+        """PGP.geoprocessing: test reclassifying nodata value."""
+        n_pixels = 9
+        pixel_matrix = numpy.ones((n_pixels, n_pixels), numpy.float32)
+        test_value = 0.5
+        pixel_matrix[:] = test_value
+        nodata = -1
+        pixel_matrix[0,0] = nodata
+        pixel_matrix[5,7] = nodata
+        raster_path = os.path.join(self.workspace_dir, 'raster.tif')
+        target_path = os.path.join(self.workspace_dir, 'target.tif')
+        _array_to_raster(
+            pixel_matrix, nodata, raster_path)
+
+        value_map = {
+            test_value: 0,
+            nodata: 1,
+        }
+        target_nodata = -1
+        pygeoprocessing.reclassify_raster(
+            (raster_path, 1), value_map, target_path, gdal.GDT_Float32,
+            target_nodata, values_required=True)
+        target_array = pygeoprocessing.raster_to_numpy_array(target_path)
+        self.assertAlmostEqual(numpy.sum(target_array), 2)
+
+    def test_reclassify_raster_reclass_max_nodata(self):
+        """PGP.geoprocessing: test reclassifying max nodata value."""
+        n_pixels = 9
+        pixel_matrix = numpy.ones((n_pixels, n_pixels), numpy.float32)
+        test_value = 0.5
+        pixel_matrix[:] = test_value
+        nodata = numpy.finfo(numpy.float32).max - 1
+        pixel_matrix[0,0] = nodata
+        pixel_matrix[5,7] = nodata
+        raster_path = os.path.join(self.workspace_dir, 'raster.tif')
+        target_path = os.path.join(self.workspace_dir, 'target.tif')
+        _array_to_raster(
+            pixel_matrix, nodata, raster_path)
+
+        value_map = {
+            test_value: 0,
+            nodata: 1,
+        }
+        target_nodata = -1
+        pygeoprocessing.reclassify_raster(
+            (raster_path, 1), value_map, target_path, gdal.GDT_Float32,
+            target_nodata, values_required=True)
+        target_array = pygeoprocessing.raster_to_numpy_array(target_path)
+        self.assertAlmostEqual(numpy.sum(target_array), 2)
+
     def test_reproject_vector(self):
         """PGP.geoprocessing: test reproject vector."""
         # Create polygon shapefile to reproject


### PR DESCRIPTION
Adding ability for nodata to be reclassified if it is in the `value_map` for `reclassify_raster`.

Added two new tests and updated history.