### PR TITLE
Adding a test for signed_byte raster_calculator operations.

### DIFF
--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2099,9 +2099,8 @@ class TestGeoprocessing(unittest.TestCase):
 
         target_array = pygeoprocessing.raster_to_numpy_array(target_path)
         # We expect that any values less than 0 are converted to 2.
-        # This ensures that
-        # we expect a negative result even though we put in a positive because
-        # we know signed bytes will convert.
+        # This ensures that we expect a negative result even though we
+        # put in a positive because we know signed bytes will convert.
         self.assertEqual(target_array[0, 0], 2)
         self.assertEqual(target_array.sum(), 128 * 128 + 1)
         self.assertEqual(list(numpy.unique(target_array)), [1, 2])

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2106,6 +2106,15 @@ class TestGeoprocessing(unittest.TestCase):
         self.assertEqual(target_array.sum(), 128 * 128 + 1)
         self.assertEqual(list(numpy.unique(target_array)), [1, 2])
 
+        # Nodata value is not set, so it should come back as ``None``.
+        try:
+            target_raster = gdal.OpenEx(target_path)
+            target_band = target_raster.GetRasterBand(1)
+            self.assertEqual(target_band.GetNoDataValue(), None)
+        finally:
+            target_band = None
+            target_raster = None
+
     def test_new_raster_from_base_unsigned_byte(self):
         """PGP.geoprocessing: test that signed byte rasters copy over."""
         pixel_array = numpy.ones((128, 128), numpy.byte)


### PR DESCRIPTION
From what I've read in the source code, signed byte support in GDAL appears to be very good, provided that the appropriate metadata is set (and it's this metadata that GDAL uses to determine whether a raster is a signed byte type).

This test just adds a functional test for raster calculator to make sure that we can interpret signed byte values correctly in a local op.

RE #42