### PR TITLE
Check for mismatched attributes in shapely_geometry_to_vector

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+Unreleased Changes
+------------------
+* Fixing a bug in ``shapely_geometry_to_vector`` where a feature name mismatch
+  between the ``fields`` and ``attribute_list`` inputs would silently pass
+  under most circumstances.  Now an informative ``ValueError`` is raised.
+
 2.3.2 (2021-09-08)
 ------------------
 * Restore functionality in ``reclassify_raster`` that allows for nodata

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -3598,12 +3598,19 @@ def shapely_geometry_to_vector(
         target_layer.CreateField(ogr.FieldDefn(field_name, field_type))
     layer_defn = target_layer.GetLayerDefn()
 
-    for shapely_feature, fields in zip(shapely_geometry_list, attribute_list):
+    for field_index, (shapely_feature, feature_attributes) in enumerate(
+            zip(shapely_geometry_list, attribute_list)):
         new_feature = ogr.Feature(layer_defn)
         new_geometry = ogr.CreateGeometryFromWkb(shapely_feature.wkb)
         new_feature.SetGeometry(new_geometry)
 
-        for field_name, field_value in fields.items():
+        if set(fields.keys()) != set(feature_attributes.keys()):
+            raise ValueError(
+                f"The fields and attributes for feature {field_index} "
+                f"do not match.  Field definitions={fields}. "
+                f"Feature attributes={feature_attributes}.")
+
+        for field_name, field_value in feature_attributes.items():
             new_feature.SetField(field_name, field_value)
         target_layer.CreateFeature(new_feature)
 

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -4619,3 +4619,20 @@ class TestGeoprocessing(unittest.TestCase):
         numpy.testing.assert_almost_equal(
             pygeoprocessing.raster_to_numpy_array(int_out_path),
             array)
+
+    def test_geometry_field_mismatch(self):
+        """PGP: test exception in field name mismatch."""
+        projection = osr.SpatialReference()
+        projection.ImportFromEPSG(3116)
+        with self.assertRaises(ValueError) as cm:
+            pygeoprocessing.shapely_geometry_to_vector(
+                [shapely.geometry.Point(1, -1)],
+                os.path.join(self.workspace_dir, 'vector.gpkg'),
+                projection.ExportToWkt(),
+                'GPKG',
+                fields={'field_a': ogr.OFTReal},
+                attribute_list=[{'field_b': 123}],
+                ogr_geom_type=ogr.wkbPoint)
+
+        self.assertIn(
+            "The fields and attributes for feature 0", str(cm.exception))


### PR DESCRIPTION
`shapely_geometry_to_vector` will now raise an exception when the provided attributes of a feature don't match the defined fields.

Fixes #226 

This PR is currently in draft while I debug a build issue.