### PR TITLE
Test pygeoprocessing against python 3.10 (and replace setup.py commands)

### DIFF
--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -8,7 +8,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [windows-latest, macos-latest]
-                python-version: [3.7, 3.8, 3.9]
+                python-version: [3.7, 3.8, 3.9, "3.10"]
                 python-arch: [x86, x64]
                 include:
                     - python-version: 3.7
@@ -17,6 +17,8 @@ jobs:
                       numpy: "numpy~=1.17"
                     - python-version: 3.9
                       numpy: "numpy~=1.19"
+                    - python-version: "3.10"
+                      numpy: "numpy~=1.21"
 
                 exclude:
                     - os: macos-latest

--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -24,9 +24,6 @@ jobs:
                     - os: macos-latest
                       python-arch: x86
 
-                    - python-version: "3.10"
-                      python-arch: x86
-
         steps:
             - uses: actions/checkout@v2
               with:

--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -24,6 +24,9 @@ jobs:
                     - os: macos-latest
                       python-arch: x86
 
+                    - python-version: "3.10"
+                      python-arch: x86
+
         steps:
             - uses: actions/checkout@v2
               with:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -38,7 +38,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install mamba -n base -c conda-forge
-          mamba upgrade -y pip setuptools
+          conda upgrade -y pip setuptools
 
       - name: Install PyGeoprocessing
         shell: bash -l {0}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -53,7 +53,7 @@ jobs:
         shell: bash -l {0}
         run: |
             mamba install --file requirements.txt
-            mamba install gdal==${{ matrix.gdal }} pytest
+            mamba install -c conda-forge gdal==${{ matrix.gdal }} pytest
             python setup.py install
 
       - name: Test with pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -34,16 +34,19 @@ jobs:
           auto-update-conda: false
           python-version: ${{ matrix.python-version }}
           channels: conda-forge, anaconda
+
       - name: Install dependencies
         shell: bash -l {0}
-        run: conda upgrade -y pip setuptools
+        run: |
+          conda install mamba -n base -c conda-forge
+          mamba upgrade -y pip setuptools
 
       - name: Install PyGeoprocessing
         shell: bash -l {0}
         run: |
-            conda install --file requirements.txt
-            conda install $PACKAGES
-            conda install gdal==${{ matrix.gdal }}
+            mamba install --file requirements.txt
+            mamba install $PACKAGES
+            mamba install gdal==${{ matrix.gdal }}
             python setup.py install
 
       - name: Lint with flake8

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -27,6 +27,7 @@ jobs:
       - name: setup-miniconda
         uses: conda-incubator/setup-miniconda@v2
         with:
+          mamba-version: "*"
           activate-environment: pyenv
           auto-update-conda: false
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,9 +13,12 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
         exclude:
-          # No conda-forge builds of GDAL 3.2.2 for python 3.10
+          # No conda-forge builds of GDAL 3.2.2 or 3.3.0 for python 3.10
           - python-version: "3.10"
             gdal: "3.2.2"
+
+          - python-version: "3.10"
+            gdal: "3.3.0"
 
     steps:
       - uses: actions/checkout@v2
@@ -55,6 +58,7 @@ jobs:
         run: |
             mamba install --file requirements.txt
             mamba install -c conda-forge gdal==${{ matrix.gdal }} pytest
+            mamba upgrade -y setuptools
             python setup.py install
 
       - name: Test with pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,7 +35,6 @@ jobs:
       - name: setup-miniconda
         uses: conda-incubator/setup-miniconda@v2
         with:
-          mamba-version: "*"
           activate-environment: pyenv
           auto-update-conda: false
           python-version: ${{ matrix.python-version }}
@@ -44,7 +43,6 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          conda install mamba -n base -c conda-forge
           conda upgrade -y pip setuptools
           conda install -y flake8
 
@@ -61,8 +59,8 @@ jobs:
       - name: Install PyGeoprocessing
         shell: bash -l {0}
         run: |
-            mamba install -c conda-forge --file requirements.txt
-            mamba install -c conda-forge gdal==${{ matrix.gdal }} pytest setuptools build
+            conda install -c conda-forge --file requirements.txt
+            conda install -c conda-forge gdal==${{ matrix.gdal }} pytest setuptools build
             python -m build --wheel
             python -m pip install pygeoprocessing --find-links=dist
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -6,7 +6,7 @@ jobs:
   Test:
     runs-on: ${{ matrix.os }}
     env:
-        PACKAGES: "pytest flake8"
+      PACKAGES: "pytest flake8"
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -21,37 +21,40 @@ jobs:
             gdal: "3.2.2"
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-          # Fetch all history so that setuptool_scm can build the correct version string.
+      - uses: actions/checkout@v2
+        with:
+          # Fetch all history so that setuptool_scm can build the correct
+          # version string.
           fetch-depth: 0
 
-    - name: setup-miniconda
-      uses: conda-incubator/setup-miniconda@v2
-      with:
-        activate-environment: pyenv
-        auto-update-conda: false
-        python-version: ${{ matrix.python-version }}
-        channels: conda-forge, anaconda
-    - name: Install dependencies
-      shell: bash -l {0}
-      run: conda upgrade -y pip setuptools
+      - name: setup-miniconda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: pyenv
+          auto-update-conda: false
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge, anaconda
+      - name: Install dependencies
+        shell: bash -l {0}
+        run: conda upgrade -y pip setuptools
 
-    - name: Install PyGeoprocessing
-      shell: bash -l {0}
-      run: |
-          conda install --file requirements.txt
-          conda install $PACKAGES
-          conda install gdal==${{ matrix.gdal }}
-          python setup.py install
+      - name: Install PyGeoprocessing
+        shell: bash -l {0}
+        run: |
+            conda install --file requirements.txt
+            conda install $PACKAGES
+            conda install gdal==${{ matrix.gdal }}
+            python setup.py install
 
-    - name: Lint with flake8
-      shell: bash -l {0}
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      shell: bash -l {0}
-      run: pytest
+      - name: Lint with flake8
+        shell: bash -l {0}
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127
+          # chars wide
+          flake8 . --count --exit-zero --max-complexity=10 \
+            --max-line-length=127 --statistics
+      - name: Test with pytest
+        shell: bash -l {0}
+        run: pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,16 +9,13 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10"]
-        gdal: [3.2.2, 3.3.0, 3.4.0]
+        gdal: ["3.2.2", "3.3.0", "3.4.0"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
         exclude:
           # No conda-forge builds of GDAL 3.2.2 or 3.3.0 for python 3.10
           - python-version: "3.10"
-            gdal: "3.2.2"
-
-          - python-version: "3.10"
-            gdal: "3.3.0"
+            gdal: ["3.2.2", "3.3.0"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -5,8 +5,6 @@ on: [push, pull_request]
 jobs:
   Test:
     runs-on: ${{ matrix.os }}
-    env:
-      PACKAGES: "pytest flake8"
     strategy:
       fail-fast: false
       matrix:
@@ -39,14 +37,7 @@ jobs:
         run: |
           conda install mamba -n base -c conda-forge
           conda upgrade -y pip setuptools
-
-      - name: Install PyGeoprocessing
-        shell: bash -l {0}
-        run: |
-            mamba install --file requirements.txt
-            mamba install $PACKAGES
-            mamba install gdal==${{ matrix.gdal }}
-            python setup.py install
+          conda install -y flake8
 
       - name: Lint with flake8
         shell: bash -l {0}
@@ -57,6 +48,14 @@ jobs:
           # chars wide
           flake8 . --count --exit-zero --max-complexity=10 \
             --max-line-length=127 --statistics
+
+      - name: Install PyGeoprocessing
+        shell: bash -l {0}
+        run: |
+            mamba install --file requirements.txt
+            mamba install gdal==${{ matrix.gdal }} pytest
+            python setup.py install
+
       - name: Test with pytest
         shell: bash -l {0}
         run: pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,12 +16,12 @@ jobs:
           # No conda-forge builds of GDAL 3.2.2 or 3.3.0 for python 3.10
           - python-version: "3.10"
             gdal: ["3.2.2", "3.3.0"]
-            os: ${{ matrix.os }}
+            os: "*"
 
         include:
           - python-version: "3.10"
             gdal: "3.3.3"
-            os: ${{ matrix.os }}
+            os: "*"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,6 +16,12 @@ jobs:
           # No conda-forge builds of GDAL 3.2.2 or 3.3.0 for python 3.10
           - python-version: "3.10"
             gdal: ["3.2.2", "3.3.0"]
+            os: ${{ matrix.os }}
+
+        include:
+          - python-version: "3.10"
+            gdal: "3.3.3"
+            os: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -61,10 +61,10 @@ jobs:
       - name: Install PyGeoprocessing
         shell: bash -l {0}
         run: |
-            mamba install --file requirements.txt
-            mamba install -c conda-forge gdal==${{ matrix.gdal }} pytest
-            mamba upgrade -y setuptools
-            python setup.py install
+            mamba install -c conda-forge --file requirements.txt
+            mamba install -c conda-forge gdal==${{ matrix.gdal }} pytest setuptools build
+            python -m build --wheel
+            python -m pip install pygeoprocessing --find-links=dist
 
       - name: Test with pytest
         shell: bash -l {0}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,9 +11,14 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
-        gdal: [3.2.2, 3.3.0]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
+        gdal: [3.2.2, 3.3.0, 3.4.0]
         os: [ubuntu-latest, windows-latest, macos-latest]
+
+        exclude:
+          # No conda-forge builds of GDAL 3.2.2 for python 3.10
+          - python-version: "3.10"
+            gdal: "3.2.2"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,20 +8,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9]
         gdal: ["3.2.2", "3.3.0", "3.4.0"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
-        exclude:
-          # No conda-forge builds of GDAL 3.2.2 or 3.3.0 for python 3.10
-          - python-version: "3.10"
-            gdal: ["3.2.2", "3.3.0"]
-            os: "*"
-
         include:
           - python-version: "3.10"
-            gdal: "3.3.3"
-            os: "*"
+            gdal: "3.4.0"
+            os: ubuntu-latest
+
+          - python-version: "3.10"
+            gdal: "3.4.0"
+            os: windows-latest
+
+          - python-version: "3.10"
+            gdal: "3.4.0"
+            os: macos-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,6 @@ jobs:
       PACKAGES: "pytest flake8"
     strategy:
       fail-fast: false
-      max-parallel: 4
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10"]
         gdal: [3.2.2, 3.3.0, 3.4.0]

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 Release History
 ===============
 
+Unreleased Changes
+------------------
+* Testing against Python 3.10.
+
 2.3.2 (2021-09-08)
 ------------------
 * Restore functionality in ``reclassify_raster`` that allows for nodata

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,9 @@ setup(
         'Operating System :: POSIX',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Scientific/Engineering :: GIS',
         'License :: OSI Approved :: BSD License'
     ],


### PR DESCRIPTION
This PR fixes #225 (for testing against python 3.10) and also #230 (for deprecating setup.py commands).  The latter change is because `python setup.py install` fails in python 3.10 so it's time to use a different set of tools.

Most of the changes to the `.yml` files should just be whitespace, aside from a little matrix modification to test pygeoprocessing on 3.10 using the latest version of GDAL (since none of the earlier python versions have builds for GDAL on conda-forge).