### PR TITLE
`raster_calculator` wrapper

### DIFF
--- a/src/pygeoprocessing/geoprocessing_core.pyx
+++ b/src/pygeoprocessing/geoprocessing_core.pyx
@@ -28,9 +28,13 @@ from osgeo import osr
 import numpy
 import pygeoprocessing
 
-DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS = ('GTIFF', (
-    'TILED=YES', 'BIGTIFF=YES', 'COMPRESS=LZW',
-    'BLOCKXSIZE=256', 'BLOCKYSIZE=256'))
+
+DEFAULT_CREATION_OPTIONS = ('TILED=YES', 'BIGTIFF=YES', 'COMPRESS=LZW',
+                             'BLOCKXSIZE=256', 'BLOCKYSIZE=256')
+INT8_CREATION_OPTIONS = DEFAULT_CREATION_OPTIONS + (
+    'PIXELTYPE=SIGNEDBYTE',)
+DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS = ('GTIFF', DEFAULT_CREATION_OPTIONS)
+INT8_GTIFF_CREATION_TUPLE_OPTIONS = ('GTIFF', INT8_CREATION_OPTIONS)
 
 # In GDAL 3.0 spatial references no longer ignore Geographic CRS Axis Order
 # and conform to Lat first, Lon Second. Transforms expect (lat, lon) order


### PR DESCRIPTION
Draft solution for #235. I'm requesting everyone's review because this (or a different solution) could affect a lot of code in invest. See the similar, expression-based function [`evaluate_raster_calculator_expression`](https://github.com/natcap/pygeoprocessing/blob/e994119e4c04f1b68867da87d416085935bdbdf4/src/pygeoprocessing/symbolic.py#L14) for comparison.

This adds a new function `raster_op` (suggestions for the name are welcome!) and unit tests for it. Here are some key points:

* Takes in a callable rather than an expression for maximum flexibility
* User may provide a target dtype, or let an appropriate one be chosen automatically
* User may provide a target nodata value, or let an appropriate one be chosen automatically
* If the user provides a target nodata value and it can't be safely cast to the target dtype (whether automatically chosen or not), a `ValueError` is raised. This is an easy mistake that would probably never be intentional.
* In contrast, all target dtypes are allowed even if casting the data to that dtype loses information. E.g. a float32 input and a target dtype of int8 is valid. I'm not sure if we have any use case for intentionally casting to a smaller type - I'd be equally happy to make this raise `ValueError`.
* Unlike `evaluate_raster_calculator_expression`, I did not include `default_nan` and `default_inf` options to fill in any `nan` and `inf` values. I can't think of any use cases for those in invest - I think it's fine to let `nan`s and `inf`s pass through. If we do want to replace `nan` or `inf`, that can easily be done in the `op`.