### PR TITLE
pin numpy versions in pyproject.toml

### DIFF
--- a/.github/workflows/auto-pr-from-master-into-releases.yml
+++ b/.github/workflows/auto-pr-from-master-into-releases.yml
@@ -27,7 +27,6 @@ jobs:
             - run: sudo apt-get update && sudo apt-get install gettext-base
 
             - name: Open a PR into each open release branch
-              shell: bash
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   SOURCE_BRANCH: ${{ env.SOURCE_BRANCH }}

--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -10,16 +10,6 @@ jobs:
                 os: [windows-latest, macos-latest]
                 python-version: [3.7, 3.8, 3.9, "3.10"]
                 python-arch: [x86, x64]
-                include:
-                    - python-version: 3.7
-                      numpy: "numpy~=1.15"
-                    - python-version: 3.8
-                      numpy: "numpy~=1.17"
-                    - python-version: 3.9
-                      numpy: "numpy~=1.19"
-                    - python-version: "3.10"
-                      numpy: "numpy~=1.21"
-
                 exclude:
                     - os: macos-latest
                       python-arch: x86
@@ -40,10 +30,10 @@ jobs:
                   architecture: ${{ matrix.python-arch }}
 
             - name: Install dependencies
-              run: python -m pip install ${{ matrix.numpy }} setuptools_scm cython wheel
+              run: python -m pip install build
 
             - name: Build wheel
-              run: python setup.py bdist_wheel
+              run: python -m build --wheel
 
             - uses: actions/upload-artifact@v1
               with:
@@ -67,11 +57,11 @@ jobs:
               with:
                   python-version: 3.7
 
-            - name: Install python dependencies
-              run: python -m pip install --upgrade pip numpy setuptools_scm cython
+            - name: Install dependencies
+              run: python -m pip install build
 
             - name: Build source distribution
-              run: python setup.py build_ext sdist
+              run: python -m build --sdist
 
             - uses: actions/upload-artifact@v1
               with:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -2,6 +2,10 @@ name: Test PyGeoprocessing
 
 on: [push, pull_request]
 
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   Test:
     runs-on: ${{ matrix.os }}
@@ -38,16 +42,12 @@ jobs:
           activate-environment: pyenv
           auto-update-conda: false
           python-version: ${{ matrix.python-version }}
-          channels: conda-forge, anaconda
+          channels: conda-forge
 
       - name: Install dependencies
-        shell: bash -l {0}
-        run: |
-          conda upgrade -y pip setuptools
-          conda install -y flake8
+        run: conda install flake8 pytest
 
       - name: Lint with flake8
-        shell: bash -l {0}
         run: |
           # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
@@ -57,13 +57,11 @@ jobs:
             --max-line-length=127 --statistics
 
       - name: Install PyGeoprocessing
-        shell: bash -l {0}
         run: |
-            conda install -c conda-forge --file requirements.txt
-            conda install -c conda-forge gdal==${{ matrix.gdal }} pytest setuptools build
+            conda install --file requirements.txt
+            conda install gdal==${{ matrix.gdal }} setuptools build
             python -m build --wheel
             python -m pip install pygeoprocessing --find-links=dist
 
       - name: Test with pytest
-        shell: bash -l {0}
         run: pytest

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,10 @@ Unreleased Changes
   between the ``fields`` and ``attribute_list`` inputs would silently pass
   under most circumstances.  Now an informative ``ValueError`` is raised.
 * Testing against Python 3.10.
+* Pinned ``numpy`` versions in ``pyproject.toml`` to the lowest compatible
+  version for each supported python version. This prevents issues when
+  ``pygeoprocessing`` is used in an environment with a lower numpy version
+  than it was built with (https://github.com/cython/cython/issues/4452).
 
 2.3.2 (2021-09-08)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,4 +5,12 @@
 # dynamically import GDAL via python's import system.  This behavior means
 # that we can provide a much easier build experience so long as GDAL is
 # available at runtime.
-requires = ['setuptools', 'wheel', 'setuptools_scm', 'numpy', 'cython']
+requires = [
+    'setuptools', 'wheel', 'setuptools_scm', 'cython',
+    # use minimum compatible numpy for each python version
+    # https://github.com/cython/cython/issues/4452
+    'numpy==1.16.5; python_version=="3.7"',
+    'numpy==1.17.3; python_version=="3.8"',
+    'numpy==1.19.3; python_version=="3.9"',
+    'numpy==1.21.2; python_version=="3.10"']
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Pin `numpy` to the minimum compatible versions in pyproject.toml `build-system` `requires`. Necessary for natcap/invest.users-guide#62. Pygeoprocessing is getting built from source on ReadTheDocs using whatever the latest numpy version is (1.22.0). It later gets downgraded to numpy 1.21.5 to be compatible with invest. The pygeoprocessing built with the newer numpy version conflicts.

Also removed some redundant lines in the workflow yml.