### PR TITLE
Elevate warnings to exceptions when running tests

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -62,7 +62,7 @@ jobs:
             conda install --file requirements.txt
             conda install gdal==${{ matrix.gdal }} setuptools build
             python -m build --wheel
-            python -m pip install pygeoprocessing --find-links=dist
+            python -m pip install $(find dist -name "*.whl")
 
       - name: Test with pytest
         run: pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,6 +9,7 @@ defaults:
 jobs:
   Test:
     runs-on: ${{ matrix.os }}
+    name: Test (py${{ matrix.python-version }}, GDAL ${{ matrix.gdal }}, ${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 Release History
 ===============
 
+Unreleased Changes
+------------------
+* ``calculate_disjoint_polygon_set`` will now skip over empty geometries.
+  Previously, the presence of empty geometries would cause an error to be
+  raised.
+* Fixed a ``DeprecationWarning`` in ``calculate_disjoint_polygon_set`` caused
+  by the use of a deprecated logging ``warn`` method.
+
 2.3.3.post0 (2022-01-28)
 ------------------------
 * Post-release due to corrupted sdist released on Github and PyPI. The sdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,8 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 # Raise warnings to exceptions.
 filterwarnings = 'error'
+
+
+[tool.setuptools_scm]
+version_scheme = "post-release"
+local_scheme = "node-and-date"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,8 @@ requires = [
     'numpy==1.19.3; python_version=="3.9"',
     'numpy==1.21.2; python_version=="3.10"']
 build-backend = "setuptools.build_meta"
+
+
+[tool.pytest.ini_options]
+# Raise warnings to exceptions.
+filterwarnings = 'error'

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@
 import platform
 
 import numpy
-from setuptools.extension import Extension
 from setuptools import setup
+from setuptools.extension import Extension
 
 # Read in requirements.txt and populate the python readme with the non-comment
 # contents.
@@ -38,10 +38,7 @@ setup(
     package_dir={
         'pygeoprocessing': 'src/pygeoprocessing'
     },
-    use_scm_version={
-        'version_scheme': 'post-release',
-        'local_scheme': 'node-and-date'},
-    setup_requires=['setuptools_scm', 'cython', 'numpy'],
+    setup_requires=['cython', 'numpy'],
     include_package_data=True,
     install_requires=_REQUIREMENTS,
     license='BSD',

--- a/src/pygeoprocessing/__init__.py
+++ b/src/pygeoprocessing/__init__.py
@@ -6,14 +6,27 @@ import logging
 import sys
 import types
 
+import pkg_resources
+import pkg_resources.extern.packaging.version
+
 from . import geoprocessing
 from .geoprocessing import ReclassificationMissingValuesError
 from .geoprocessing_core import calculate_slope
 from .geoprocessing_core import raster_band_percentile
-import pkg_resources
-__version__ = pkg_resources.get_distribution(__name__).version
 
-__all__ = ('calculate_slope', 'raster_band_percentile', 
+try:
+    __version__ = pkg_resources.get_distribution(__name__).version
+except (pkg_resources.extern.packaging.version.InvalidVersion,
+        DeprecationWarning):
+    # InvalidVersion is raised when our version string isn't PEP440.
+    # If there was an error, just skip the version string.
+    # Not having a version string shouldn't change how pygeoprocessing behaves
+    # or whether it imports.
+    # DeprecationWarning sometimes happens when we have an invalid version
+    # string as well.
+    __version__ = 'unknown'
+
+__all__ = ('calculate_slope', 'raster_band_percentile',
            'ReclassificationMissingValuesError')
 for attrname in dir(geoprocessing):
     attribute = getattr(geoprocessing, attrname)

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2278,7 +2278,6 @@ def calculate_disjoint_polygon_set(
                 f'empty geometry in {vector_path} FID: {poly_feat.GetFID()}, '
                 'skipping...')
             continue
-        LOGGER.info(poly_geom_ref.ExportToWkt())
         # with GDAL>=3.3.0 ExportToWkb returns a bytearray instead of bytes
         shapely_polygon_lookup[poly_feat.GetFID()] = (
             shapely.wkb.loads(bytes(poly_geom_ref.ExportToWkb())))

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2267,7 +2267,7 @@ def calculate_disjoint_polygon_set(
     for poly_feat in vector_layer:
         poly_geom_ref = poly_feat.GetGeometryRef()
         if poly_geom_ref is None:
-            LOGGER.warn(
+            LOGGER.warning(
                 f'no geometry in {vector_path} FID: {poly_feat.GetFID()}, '
                 'skipping...')
             continue

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2262,9 +2262,6 @@ def calculate_disjoint_polygon_set(
         bounding_box = get_vector_info(vector_path)['bounding_box']
     bounding_box = shapely.prepared.prep(shapely.geometry.box(*bounding_box))
 
-    # As much as I want this to be in a comprehension, a comprehension version
-    # of this loop causes python 3.6 to crash on linux in GDAL 2.1.2 (which is
-    # what's in the debian:stretch repos.)
     shapely_polygon_lookup = {}
     for poly_feat in vector_layer:
         poly_geom_ref = poly_feat.GetGeometryRef()

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -13,12 +13,6 @@ import tempfile
 import threading
 import time
 
-from . import geoprocessing_core
-from .geoprocessing_core import DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS
-from .geoprocessing_core import DEFAULT_OSR_AXIS_MAPPING_STRATEGY
-from osgeo import gdal
-from osgeo import ogr
-from osgeo import osr
 import numpy
 import numpy.ma
 import rtree
@@ -30,6 +24,13 @@ import scipy.sparse
 import shapely.ops
 import shapely.prepared
 import shapely.wkb
+from osgeo import gdal
+from osgeo import ogr
+from osgeo import osr
+
+from . import geoprocessing_core
+from .geoprocessing_core import DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS
+from .geoprocessing_core import DEFAULT_OSR_AXIS_MAPPING_STRATEGY
 
 # This is used to efficiently pass data to the raster stats worker if available
 if sys.version_info >= (3, 8):

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1415,9 +1415,10 @@ def zonal_statistics(
         unset_feat = aggregate_layer.GetFeature(unset_fid)
         unset_geom_ref = unset_feat.GetGeometryRef()
         if unset_geom_ref is None:
-            LOGGER.warn(
+            LOGGER.warning(
                 f'no geometry in {aggregate_vector_path} FID: {unset_fid}')
             continue
+
         unset_geom_envelope = list(unset_geom_ref.GetEnvelope())
         unset_geom_ref = None
         unset_feat = None

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2272,6 +2272,12 @@ def calculate_disjoint_polygon_set(
                 f'no geometry in {vector_path} FID: {poly_feat.GetFID()}, '
                 'skipping...')
             continue
+        if poly_geom_ref.IsEmpty():
+            LOGGER.warning(
+                f'empty geometry in {vector_path} FID: {poly_feat.GetFID()}, '
+                'skipping...')
+            continue
+        LOGGER.info(poly_geom_ref.ExportToWkt())
         # with GDAL>=3.3.0 ExportToWkb returns a bytearray instead of bytes
         shapely_polygon_lookup[poly_feat.GetFID()] = (
             shapely.wkb.loads(bytes(poly_geom_ref.ExportToWkb())))

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -661,7 +661,7 @@ class TestGeoprocessing(unittest.TestCase):
         feature = next(iter(target_layer))
         feature_geom = shapely.wkt.loads(
             feature.GetGeometryRef().ExportToWkt())
-        self.assertTrue(feature_geom.almost_equals(polygon_a))
+        self.assertTrue(feature_geom.equals_exact(polygon_a, 1e-6))
 
     def test_reproject_vector_utm_to_utm(self):
         """PGP.geoprocessing: reproject vector from utm to utm."""

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -3210,7 +3210,7 @@ class TestGeoprocessing(unittest.TestCase):
                 working_dir=self.workspace_dir)
             target_array = pygeoprocessing.raster_to_numpy_array(
                 target_distance_raster_path)
-            expected_result = scipy.ndimage.morphology.distance_transform_edt(
+            expected_result = scipy.ndimage.distance_transform_edt(
                 1 - (base_raster_array == 1), sampling=(
                     sampling_distance[1], sampling_distance[0]))
             numpy.testing.assert_array_almost_equal(
@@ -3248,7 +3248,7 @@ class TestGeoprocessing(unittest.TestCase):
             working_dir=self.workspace_dir)
         target_array = pygeoprocessing.raster_to_numpy_array(
             target_distance_raster_path)
-        expected_result = scipy.ndimage.morphology.distance_transform_edt(
+        expected_result = scipy.ndimage.distance_transform_edt(
             1 - (base_raster_array == 1), sampling=(
                 sampling_distance[1], sampling_distance[0]))
         numpy.testing.assert_array_almost_equal(

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -753,6 +753,13 @@ class TestGeoprocessing(unittest.TestCase):
                 expected_value = row_index // 2 * n + col_index // 2
                 new_feature.SetField('expected_value', expected_value)
                 layer.CreateFeature(new_feature)
+
+        # Now create one additional feature that has no geometry in order to
+        # exercise a warning.
+        new_feature = ogr.Feature(layer_defn)
+        new_feature.SetField('expected_value', 0)
+        layer.CreateFeature(new_feature)
+
         layer.CommitTransaction()
         layer.SyncToDisk()
 

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -9,20 +9,19 @@ import types
 import unittest
 import unittest.mock
 
-from osgeo import gdal
-from osgeo import ogr
-from osgeo import osr
-from numpy.random import MT19937
-from numpy.random import RandomState
-from numpy.random import SeedSequence
 import numpy
-import scipy.ndimage
-import shapely.geometry
-import shapely.wkt
-
 import pygeoprocessing
 import pygeoprocessing.multiprocessing
 import pygeoprocessing.symbolic
+import scipy.ndimage
+import shapely.geometry
+import shapely.wkt
+from numpy.random import MT19937
+from numpy.random import RandomState
+from numpy.random import SeedSequence
+from osgeo import gdal
+from osgeo import ogr
+from osgeo import osr
 from pygeoprocessing.geoprocessing_core import \
     DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS
 

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -815,6 +815,12 @@ class TestGeoprocessing(unittest.TestCase):
                 expected_value = row_index // 2 * n + col_index // 2
                 new_feature.SetField('expected_value', expected_value)
                 layer.CreateFeature(new_feature)
+
+        # Add a feature with no geometry to make sure we can handle it.
+        new_feature = ogr.Feature(layer_defn)
+        new_feature.SetField('expected_value', 0)
+        layer.CreateFeature(new_feature)
+
         layer.CommitTransaction()
         layer.SyncToDisk()
 
@@ -826,7 +832,7 @@ class TestGeoprocessing(unittest.TestCase):
 
         zonal_stats = pygeoprocessing.zonal_statistics(
             (raster_path, 1), vector_path)
-        self.assertEqual(len(zonal_stats), 4*n*n)
+        self.assertEqual(len(zonal_stats), 4*n*n + 1)
         for poly_id in zonal_stats:
             feature = layer.GetFeature(poly_id)
             self.assertEqual(

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -759,6 +759,13 @@ class TestGeoprocessing(unittest.TestCase):
         new_feature.SetField('expected_value', 0)
         layer.CreateFeature(new_feature)
 
+        # Now create one more feature, but with valid (but empty) geometry.
+        new_feature = ogr.Feature(layer_defn)
+        new_geometry = ogr.CreateGeometryFromWkt('GEOMETRYCOLLECTION EMPTY')
+        new_feature.SetGeometry(new_geometry)
+        new_feature.SetField('expected_value', 1)
+        layer.CreateFeature(new_feature)
+
         layer.CommitTransaction()
         layer.SyncToDisk()
 


### PR DESCRIPTION
This PR elevates warnings encountered in tests to exceptions.  I also went ahead and fixed all the warnings I encountered, and added some functionality to test the one mentioned in #243 as well as another related warning that will help make the `calculate_disjoint_polygon_set` function more resilient.