### PR TITLE
Plugging shared_memory leak

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,9 @@ Release History
 
 Unreleased Changes
 ------------------
+* Fixing a memory leak in ``pygeoprocessing.raster_calculator`` where
+  shared memory objects were being inadvertently created when they should not
+  have been and then they were not subsequently destroyed.
 * ``calculate_disjoint_polygon_set`` will now skip over empty geometries.
   Previously, the presence of empty geometries would cause an error to be
   raised.

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -370,7 +370,7 @@ def raster_calculator(
             stats_worker_queue = queue.Queue()
             exception_queue = queue.Queue()
 
-            if sys.version_info >= (3, 8):
+            if sys.version_info >= (3, 8) and use_shared_memory:
                 # The stats worker keeps running variables as a float64, so
                 # all input rasters are dtype float64 -- make the shared memory
                 # size equivalent.
@@ -381,7 +381,6 @@ def raster_calculator(
 
                 shared_memory = multiprocessing.shared_memory.SharedMemory(
                     create=True, size=block_size_bytes)
-
         else:
             stats_worker_queue = None
 


### PR DESCRIPTION
Objects were being created when they should not have been, and then sticking around because they shouldn't have been created in the first place.

I'm really not sure how to test this, but I can confirm that the shared memory warning is no longer present.

Fixes #247 