### PR TITLE
Fixing module-level imports to work with pylint and JEDI-vim

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -79,4 +79,4 @@ jobs:
             python -m pip install $(find dist -name "*.whl")
 
       - name: Test with pytest
-        run: pytest
+        run: python -m pytest tests

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@ Release History
 
 Unreleased Changes
 ------------------
+* Fixing an issue with imports at the ``pygeoprocessing`` module level that was
+  causing linters like PyLint and IDE command-completion programs like JEDI-vim
+  to not be able to identify the attributes of the ``pygeoprocessing`` module
+  namespace.
 * Reducing the amount of memory used by
   ``pygeoprocessing.new_raster_from_base`` when filling an array with values to
   only as much memory as is needed for the datatype.

--- a/src/pygeoprocessing/__init__.py
+++ b/src/pygeoprocessing/__init__.py
@@ -50,7 +50,8 @@ except (pkg_resources.extern.packaging.version.InvalidVersion,
     # string as well.
     __version__ = 'unknown'
 
-# Programmatically defining
+# Programmatically defining __all__ based on what's been imported.
+# Thus, the imports are the source of truth for __all__.
 __all__ = ('calculate_slope', 'raster_band_percentile',
            'ReclassificationMissingValuesError')
 for attrname in [k for k in locals().keys()]:

--- a/src/pygeoprocessing/__init__.py
+++ b/src/pygeoprocessing/__init__.py
@@ -3,14 +3,38 @@
 __init__ module imports all the geoprocessing functions into this namespace.
 """
 import logging
-import sys
 import types
 
 import pkg_resources
 import pkg_resources.extern.packaging.version
 
 from . import geoprocessing
+from .geoprocessing import _assert_is_valid_pixel_size
+from .geoprocessing import align_and_resize_raster_stack
+from .geoprocessing import calculate_disjoint_polygon_set
+from .geoprocessing import convolve_2d
+from .geoprocessing import create_raster_from_vector_extents
+from .geoprocessing import distance_transform_edt
+from .geoprocessing import get_gis_type
+from .geoprocessing import get_raster_info
+from .geoprocessing import get_vector_info
+from .geoprocessing import interpolate_points
+from .geoprocessing import iterblocks
+from .geoprocessing import mask_raster
+from .geoprocessing import merge_bounding_box_list
+from .geoprocessing import new_raster_from_base
+from .geoprocessing import numpy_array_to_raster
+from .geoprocessing import raster_calculator
+from .geoprocessing import raster_to_numpy_array
+from .geoprocessing import rasterize
 from .geoprocessing import ReclassificationMissingValuesError
+from .geoprocessing import reclassify_raster
+from .geoprocessing import reproject_vector
+from .geoprocessing import shapely_geometry_to_vector
+from .geoprocessing import stitch_rasters
+from .geoprocessing import transform_bounding_box
+from .geoprocessing import warp_raster
+from .geoprocessing import zonal_statistics
 from .geoprocessing_core import calculate_slope
 from .geoprocessing_core import raster_band_percentile
 
@@ -26,13 +50,15 @@ except (pkg_resources.extern.packaging.version.InvalidVersion,
     # string as well.
     __version__ = 'unknown'
 
+# Programmatically defining
 __all__ = ('calculate_slope', 'raster_band_percentile',
            'ReclassificationMissingValuesError')
-for attrname in dir(geoprocessing):
-    attribute = getattr(geoprocessing, attrname)
-    if isinstance(attribute, types.FunctionType):
-        __all__ += (attrname,)
-        setattr(sys.modules['pygeoprocessing'], attrname, attribute)
+for attrname in [k for k in locals().keys()]:
+    try:
+        if isinstance(getattr(geoprocessing, attrname), types.FunctionType):
+            __all__ += (attrname,)
+    except AttributeError:
+        pass
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.NullHandler())  # silence logging by default


### PR DESCRIPTION
This is a minor thing, but it's been a mild issue for _years_.  So it's fixed now and my autocomplete is working as expected in `vim` and PyLint is able to find the right attributes.

I'm really not sure how to test this, so the tests aren't updated.

RE:#266