### PR TITLE
Add value counts under polygons in zonal statistics

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@ Release History
 
 Unreleased Changes
 ------------------
+* ``pygeoprocessing.zonal_statistics`` will now optionally include a count of
+  the number of pixels per value encountered under each polygon.  A warning
+  will be logged when invoked on floating-point rasters, as using this on
+  continuous rasters can result in excessive memory consumption.  To use this
+  feature, set ``include_value_counts=True`` when calling ``zonal_statistics``.
 * Fixing an issue with imports at the ``pygeoprocessing`` module level that was
   causing linters like PyLint and IDE command-completion programs like JEDI-vim
   to not be able to identify the attributes of the ``pygeoprocessing`` module

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,15 +1,16 @@
 Release History
 ===============
 
-.. Unreleased Changes
+Unreleased Changes
+------------------
+* ``pygeoprocessing.zonal_statistics`` will now optionally include a count of
+  the number of pixels per value encountered under each polygon. A warning
+  will be logged when invoked on floating-point rasters, as using this on
+  continuous rasters can result in excessive memory consumption. To use this
+  feature, set ``include_value_counts=True`` when calling ``zonal_statistics``.
 
 2.3.4 (2022-08-22)
 ------------------
-* ``pygeoprocessing.zonal_statistics`` will now optionally include a count of
-  the number of pixels per value encountered under each polygon.  A warning
-  will be logged when invoked on floating-point rasters, as using this on
-  continuous rasters can result in excessive memory consumption.  To use this
-  feature, set ``include_value_counts=True`` when calling ``zonal_statistics``.
 * Fixing an issue with imports at the ``pygeoprocessing`` module level that was
   causing linters like PyLint and IDE command-completion programs like JEDI-vim
   to not be able to identify the attributes of the ``pygeoprocessing`` module

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1160,7 +1160,7 @@ def zonal_statistics(
         There may be some degenerate cases where the bounding box vs. actual
         geometry intersection would be incorrect, but these are so unlikely as
         to be manually constructed. If you encounter one of these please email
-        the description and dataset to richsharp@stanford.edu.
+        the description and dataset to jdouglass@stanford.edu.
 
     Args:
         base_raster_path_band (tuple): a str/int tuple indicating the path to
@@ -1486,7 +1486,7 @@ def zonal_statistics(
         # is as small as a pixel. There could be some degenerate cases that
         # make this estimation very wrong, but we do not know of any that
         # would come from natural data. If you do encounter such a dataset
-        # please email the description and datset to richsharp@stanford.edu.
+        # please email the description and datset to jdouglass@stanford.edu.
         unset_fid_block = clipped_band.ReadAsArray(
             xoff=xoff, yoff=yoff, win_xsize=win_xsize, win_ysize=win_ysize)
 

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1196,9 +1196,9 @@ def zonal_statistics(
         of 'min' 'max' 'sum' 'count' and 'nodata_count'.  Example::
 
             {0: {'min': 0,
-                 'max': 1,
-                 'sum': 1.7,
-                 'count': 3,
+                 'max': 14,
+                 'sum': 42,
+                 'count': 8,
                  'nodata_count': 1,
                  'value_counts': {
                      2: 5,

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1526,7 +1526,7 @@ def zonal_statistics(
         if include_value_counts:
             aggregate_stats[unset_fid]['value_counts'].update(
                 dict(zip(*numpy.unique(
-                    value_unset_fid_block, return_counts=True))))
+                    valid_unset_fid_block, return_counts=True))))
 
     unset_fids = aggregate_layer_fid_set.difference(aggregate_stats)
     LOGGER.debug(

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1271,7 +1271,8 @@ def zonal_statistics(
             ``collections.defaultdict`` when a key does not already exist.
         """
         sample_aggregate_dict = {
-            'min': None, 'max': None, 'count': 0, 'nodata_count': 0, 'sum': 0.0}
+            'min': None, 'max': None, 'count': 0, 'nodata_count': 0,
+            'sum': 0.0}
         if include_value_counts:
             sample_aggregate_dict['value_counts'] = collections.Counter()
         return sample_aggregate_dict

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1430,7 +1430,6 @@ def zonal_statistics(
                             collections.defaultdict(int))
                     for pixel_value, pixel_count in zip(*numpy.unique(
                             masked_clipped_block, return_counts=True)):
-                        LOGGER.info(f"{pixel_value}, {pixel_count}")
                         aggregate_stats[agg_fid][
                             'value_counts'][pixel_value] += pixel_count
     unset_fids = aggregate_layer_fid_set.difference(aggregate_stats)
@@ -1523,7 +1522,6 @@ def zonal_statistics(
                     collections.defaultdict(int))
             for pixel_value, pixel_count in zip(*numpy.unique(
                     value_unset_fid_block, return_counts=True)):
-                LOGGER.info(f"{pixel_value}, {pixel_count}")
                 aggregate_stats[unset_fid][
                     'value_counts'][pixel_value] += pixel_count
 

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1248,7 +1248,7 @@ def zonal_statistics(
     if (raster_info['datatype'] in {gdal.GDT_Float32, gdal.GDT_Float64}
             and include_value_counts):
         LOGGER.warning(
-            "Value counts requested on a floating-point raster, which can "
+            "Value counts requested on a floating-point raster which can "
             "cause excessive memory usage.")
 
     # -1 here because bands are 1 indexed
@@ -1317,7 +1317,8 @@ def zonal_statistics(
         iterblocks((agg_fid_raster_path, 1), offset_only=True))
     agg_fid_raster = gdal.OpenEx(
         agg_fid_raster_path, gdal.GA_Update | gdal.OF_RASTER)
-    aggregate_stats = collections.defaultdict(lambda: sample_aggregate_dict)
+    aggregate_stats = collections.defaultdict(
+        lambda: sample_aggregate_dict.copy())
     last_time = time.time()
     LOGGER.info("processing %d disjoint polygon sets", len(disjoint_fid_sets))
     for set_index, disjoint_fid_set in enumerate(disjoint_fid_sets):

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1248,8 +1248,9 @@ def zonal_statistics(
     if (raster_info['datatype'] in {gdal.GDT_Float32, gdal.GDT_Float64}
             and include_value_counts):
         LOGGER.warning(
-            "Value counts requested on a floating-point raster which can "
-            "cause excessive memory usage.")
+            "Value counts requested on a floating-point raster. This can "
+            "cause excessive memory usage if the raster has continuous "
+            "values.")
 
     # -1 here because bands are 1 indexed
     raster_nodata = raster_info['nodata'][base_raster_path_band[1]-1]

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1437,6 +1437,8 @@ def zonal_statistics(
                 aggregate_stats[agg_fid]['sum'] += numpy.sum(
                     masked_clipped_block)
                 if include_value_counts:
+                    # .update() here is operating on a Counter, so values are
+                    # ADDED, not replaced.
                     aggregate_stats[agg_fid]['value_counts'].update(
                         dict(zip(*numpy.unique(
                             masked_clipped_block, return_counts=True))))
@@ -1525,6 +1527,8 @@ def zonal_statistics(
         aggregate_stats[unset_fid]['nodata_count'] = numpy.count_nonzero(
             unset_fid_nodata_mask)
         if include_value_counts:
+            # .update() here is operating on a Counter, so values are ADDED,
+            # not replaced.
             aggregate_stats[unset_fid]['value_counts'].update(
                 dict(zip(*numpy.unique(
                     valid_unset_fid_block, return_counts=True))))

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1258,24 +1258,24 @@ def zonal_statistics(
     clipped_raster_path = os.path.join(
         temp_working_dir, 'clipped_raster.tif')
 
-    def _make_sample_dict():
-        """Build a sample aggregate dict.
+    def _new_aggregate_dict():
+        """Build a new aggregate dict for ``collections.defaultdict``.
 
         This function is needed over a lambda because it allows us to control
-        in a single place how the initial values of the
-        ``sample_aggregate_dict`` should be defined.  These are then used in
-        several ``collections.defaultdict``s in this function.
+        in a single place how the initial values of an aggregate dict should be
+        defined.  These are then used in several ``collections.defaultdict``s
+        within ``zonal_statistics``.
 
         Returns:
-            A sample aggregate dict with starter values, used for a
+            A new aggregate dict with starter values, used for a
             ``collections.defaultdict`` when a key does not already exist.
         """
-        sample_aggregate_dict = {
+        aggregate_dict = {
             'min': None, 'max': None, 'count': 0, 'nodata_count': 0,
             'sum': 0.0}
         if include_value_counts:
-            sample_aggregate_dict['value_counts'] = collections.Counter()
-        return sample_aggregate_dict
+            aggregate_dict['value_counts'] = collections.Counter()
+        return aggregate_dict
 
     try:
         align_and_resize_raster_stack(
@@ -1290,7 +1290,7 @@ def zonal_statistics(
             LOGGER.error(
                 "aggregate vector %s does not intersect with the raster %s",
                 aggregate_vector_path, base_raster_path_band)
-            aggregate_stats = collections.defaultdict(_make_sample_dict)
+            aggregate_stats = collections.defaultdict(_new_aggregate_dict)
             for feature in aggregate_layer:
                 _ = aggregate_stats[feature.GetFID()]
             return dict(aggregate_stats)
@@ -1331,7 +1331,7 @@ def zonal_statistics(
         iterblocks((agg_fid_raster_path, 1), offset_only=True))
     agg_fid_raster = gdal.OpenEx(
         agg_fid_raster_path, gdal.GA_Update | gdal.OF_RASTER)
-    aggregate_stats = collections.defaultdict(_make_sample_dict)
+    aggregate_stats = collections.defaultdict(_new_aggregate_dict)
     last_time = time.time()
     LOGGER.info("processing %d disjoint polygon sets", len(disjoint_fid_sets))
     for set_index, disjoint_fid_set in enumerate(disjoint_fid_sets):

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -1202,7 +1202,9 @@ class TestGeoprocessing(unittest.TestCase):
 
         # Raster is float32, so we expect a warning to be posted.
         self.assertEqual(len(log_messages), 1)
-        self.assertEqual(log_messages[0].level, logging.WARNING)
+        self.assertEqual(log_messages[0].levelno, logging.WARNING)
+        self.assertIn('Value counts requested on a floating-point raster',
+                      log_messages[0].msg)
         expected_result = {
             0: {
                 'count': 81,


### PR DESCRIPTION
This PR adds pixel counts under each polygon and warns the user if pixel counts have been requested on a floating-point raster.

Fixes #270 