### PR TITLE
Add filename to raster_calculator logging

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,8 @@ Release History
 
 Unreleased Changes
 ------------------
+* Adding the target filename to progress logging in
+  ``pygeoprocessing.raster_calculator``.
 * ``pygeoprocessing.zonal_statistics`` will now optionally include a count of
   the number of pixels per value encountered under each polygon. A warning
   will be logged when invoked on floating-point rasters, as using this on

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -475,7 +475,8 @@ def raster_calculator(
             pixels_processed += blocksize[0] * blocksize[1]
             last_time = _invoke_timed_callback(
                 last_time, lambda: LOGGER.info(
-                    '%.1f%% complete',
+                    '%s %.1f%% complete',
+                    os.path.basename(target_raster_path),
                     float(pixels_processed) / n_pixels * 100.0),
                 _LOGGING_PERIOD)
 


### PR DESCRIPTION
This has been bothering me for a while.  Sorry for the very short PR!  Didn't really seem like a test was necessary for something like this.

Fixes #281 