### PR TITLE
Raise ValueError if get_gis_type results in UNKOWN_TYPE

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,9 @@ Unreleased Changes
   will be logged when invoked on floating-point rasters, as using this on
   continuous rasters can result in excessive memory consumption. To use this
   feature, set ``include_value_counts=True`` when calling ``zonal_statistics``.
+* ``pygeoprocessing.get_gis_type`` will now raise a ``ValueError`` if the file
+  cannot be opened as ``gdal.OF_RASTER`` or ``gdal.OF_VECTOR``.
+  https://github.com/natcap/pygeoprocessing/issues/244
 
 2.3.4 (2022-08-22)
 ------------------

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -3347,7 +3347,7 @@ def get_gis_type(path):
         from pygeoprocessing import VECTOR_TYPE
         gis_type |= VECTOR_TYPE
         gis_vector = None
-    if gis_type == UNKNOWN_TYPE
+    if gis_type == UNKNOWN_TYPE:
         raise ValueError(
             f"Could not open {path} as a gdal.OF_RASTER or gdal.OF_VECTOR.")
     return gis_type

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -3322,15 +3322,19 @@ def get_gis_type(path):
     Args:
         path (str): path to a file on disk.
 
+    Raises:
+        ValueError
+            if ``path`` is not a file or cannot be opened as a
+            ``gdal.OF_RASTER`` or ``gdal.OF_VECTOR``.
 
     Return:
         A bitwise OR of all GIS types that PyGeoprocessing models, currently
-        this is ``pygeoprocessing.UNKNOWN_TYPE``,
+        this is
         ``pygeoprocessing.RASTER_TYPE``, or ``pygeoprocessing.VECTOR_TYPE``.
 
     """
     if not os.path.exists(path):
-        raise ValueError("%s does not exist", path)
+        raise ValueError(f"{path} does not exist.")
     from pygeoprocessing import UNKNOWN_TYPE
     gis_type = UNKNOWN_TYPE
     gis_raster = gdal.OpenEx(path, gdal.OF_RASTER)
@@ -3342,6 +3346,10 @@ def get_gis_type(path):
     if gis_vector is not None:
         from pygeoprocessing import VECTOR_TYPE
         gis_type |= VECTOR_TYPE
+        gis_vector = None
+    if gis_type == UNKNOWN_TYPE
+        raise ValueError(
+            f"Could not open {path} as a gdal.OF_RASTER or gdal.OF_VECTOR.")
     return gis_type
 
 

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -4484,14 +4484,16 @@ class TestGeoprocessing(unittest.TestCase):
             text_file.write('test')
 
         self.assertEqual(
-            pygeoprocessing.get_gis_type(text_file_path),
-            pygeoprocessing.UNKNOWN_TYPE)
-        self.assertEqual(
             pygeoprocessing.get_gis_type(raster_path),
             pygeoprocessing.RASTER_TYPE)
         self.assertEqual(
             pygeoprocessing.get_gis_type(vector_path),
             pygeoprocessing.VECTOR_TYPE)
+
+        with self.assertRaises(ValueError) as cm:
+            pygeoprocessing.get_gis_type(text_file_path)
+        actual_message = str(cm.exception)
+        self.assertTrue('Could not open' in actual_message, actual_message)
 
         with self.assertRaises(ValueError) as cm:
             pygeoprocessing.get_gis_type('totally_fake_file')

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -3659,7 +3659,7 @@ class TestGeoprocessing(unittest.TestCase):
                 [(a_raster_path, 1)], ['near'],
                 (regular_file_raster_path, 1),
                 overlap_algorithm='etch')
-        expected_message = 'Target stitch raster is not a raster.'
+        expected_message = 'Could not open'
         actual_message = str(cm.exception)
         self.assertTrue(
             expected_message in actual_message, actual_message)


### PR DESCRIPTION
`get_gis_type` returns `gdal.UNKOWN_TYPE` (0) if the file cannot be opened as a raster or vector. This is inconsistent with the rest of the API including `get_raster_info` and `get_vector_info` which raise a `ValueError` in that circumstance. It's also not intuitive that a Microsoft Word file would return a GIS type of `UNKOWN_TYPE`. PGP is a GIS processing library that only works with valid GIS types.

Fixes #244 