### PR TITLE
use oldest-supported-numpy meta package in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,7 @@
 # that we can provide a much easier build experience so long as GDAL is
 # available at runtime.
 requires = [
-    'setuptools', 'wheel', 'setuptools_scm', 'cython',
-    # use minimum compatible numpy for each python version
-    # https://github.com/cython/cython/issues/4452
-    'numpy==1.16.5; python_version=="3.7"',
-    'numpy==1.17.3; python_version=="3.8"',
-    'numpy==1.19.3; python_version=="3.9"',
-    'numpy==1.21.2; python_version=="3.10"',
-    'numpy==1.23.2; python_version=="3.11"'
+    'setuptools', 'wheel', 'setuptools_scm', 'cython', 'oldest-supported-numpy'
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Use the [`oldest-supported-numpy`](https://github.com/scipy/oldest-supported-numpy) package to manage the oldest compatible numpy version for each python version. This is a meta-package developed by the scipy org. It saves us the trouble of keeping `pyproject.toml` correct and up to date when we add support for new python versions. We had the incorrect numpy version for python 3.10 anyway.