### PR TITLE
Removing x86 builds from github actions.

### DIFF
--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -9,7 +9,7 @@ jobs:
             matrix:
                 os: [windows-latest, macos-latest]
                 python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
-                python-arch: x64
+                python-arch: [x64]
 
         steps:
             - uses: actions/checkout@v3

--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -9,10 +9,7 @@ jobs:
             matrix:
                 os: [windows-latest, macos-latest]
                 python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
-                python-arch: [x86, x64]
-                exclude:
-                    - os: macos-latest
-                      python-arch: x86
+                python-arch: x64
 
         steps:
             - uses: actions/checkout@v3

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,13 @@
 Release History
 ===============
 
+Unreleased Changes
+------------------
+* Win32 wheels of PyGeoprocessing are no longer created through our GitHub
+  Actions workflows and will no longer be produced or distributed as part of
+  our release checklist.  For details (and metrics!) see:
+  https://github.com/natcap/pygeoprocessing/issues/232
+
 
 2.3.5 (2022-12-13)
 ------------------

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2419,7 +2419,7 @@ class TestGeoprocessing(unittest.TestCase):
 
     def test_new_raster_from_base_unsigned_byte(self):
         """PGP.geoprocessing: test that signed byte rasters copy over."""
-        pixel_array = numpy.ones((128, 128), numpy.byte)
+        pixel_array = numpy.ones((128, 128), numpy.uint8)
         pixel_array[0, 0] = 255  # 255 ubyte is -1 byte
         nodata_base = -1
         base_path = os.path.join(self.workspace_dir, 'base.tif')

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2380,7 +2380,7 @@ class TestGeoprocessing(unittest.TestCase):
 
     def test_raster_calculator_signed_byte(self):
         """PGP.geoprocessing: test that signed byte pixels interpreted."""
-        pixel_array = numpy.ones((128, 128), numpy.byte)
+        pixel_array = numpy.ones((128, 128), numpy.uint8)
         # ArcGIS will create a signed byte raster with an unsigned value of 255
         # that actually is supposed to represent -1, even though the nodata
         # value will be set as -1.

--- a/tests/test_watershed_delineation.py
+++ b/tests/test_watershed_delineation.py
@@ -39,7 +39,7 @@ class WatershedDelineationTests(unittest.TestCase):
             [2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
             [2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
             [2, 2, 2, 2, 2, 2, 2, 2, 2, 2]],
-            dtype=numpy.int8)
+            dtype=numpy.uint8)
 
         srs = osr.SpatialReference()
         srs.ImportFromEPSG(32731)  # WGS84 / UTM zone 31s
@@ -110,7 +110,7 @@ class WatershedDelineationTests(unittest.TestCase):
             [2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
             [2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
             [2, 2, 2, 2, 2, 2, 2, 2, 2, 2]],
-            dtype=numpy.int8)
+            dtype=numpy.uint8)
 
         srs = osr.SpatialReference()
         srs.ImportFromEPSG(32731)  # WGS84 / UTM zone 31s


### PR DESCRIPTION
It turns out that about 0.28% of the total downloads of `pygeoprocessing` from PyPI have been for win32, so it makes sense to remove those wheels from our GHA workflows and distribution processes so that the GHA build time can be put to better use.

Fixes #232 