### PR TITLE
Add `pygeoprocessing.create_raster_from_bounding_box`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,9 @@ Release History
 
 Unreleased Changes
 ------------------
+* Adding a new function, ``pygeoprocessing.create_raster_from_bounding_box``,
+  that enables the creation of a new raster from a bounding box.
+  https://github.com/natcap/pygeoprocessing/issues/276
 * Win32 wheels of PyGeoprocessing are no longer created through our GitHub
   Actions workflows and will no longer be produced or distributed as part of
   our release checklist.  For details (and metrics!) see:

--- a/src/pygeoprocessing/__init__.py
+++ b/src/pygeoprocessing/__init__.py
@@ -13,6 +13,7 @@ from .geoprocessing import _assert_is_valid_pixel_size
 from .geoprocessing import align_and_resize_raster_stack
 from .geoprocessing import calculate_disjoint_polygon_set
 from .geoprocessing import convolve_2d
+from .geoprocessing import create_raster_from_bounding_box
 from .geoprocessing import create_raster_from_vector_extents
 from .geoprocessing import distance_transform_edt
 from .geoprocessing import get_gis_type

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1113,8 +1113,8 @@ def create_raster_from_bounding_box(
     else:
         y_source = bbox_miny
     raster_transform = [
-        x_source, target_pixel_size[0], 0.0,
-        y_source, 0.0, target_pixel_size[1]]
+        x_source, target_pixel_size[0], 0,
+        y_source, 0, target_pixel_size[1]]
     raster.SetGeoTransform(raster_transform)
 
     # Fill the band if requested.

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1078,6 +1078,72 @@ def create_raster_from_vector_extents(
     raster = None
 
 
+def create_raster_from_bounding_box(
+        target_raster_path, target_bounding_box, target_pixel_size,
+        target_pixel_type, target_srs_wkt, target_nodata=None,
+        fill_value=None):
+    """Create a raster from a given bounding box.
+    Args:
+        target_raster_path (string): The path to where the new raster should be
+            created on disk.
+        target_bounding_box (tuple): a 4-element iterable of (minx, miny,
+            maxx, maxy) in projected units matching the SRS of
+            ``target_srs_wkt``.
+        target_pixel_size (tuple): A 2-element tuple of the (x, y) pixel size
+            of the target raster.  Elements are in units of the target SRS.
+        target_pixel_type (int): The GDAL GDT_* type of the target raster.
+        target_srs_wkt (string): The SRS of the target raster, in Well-Known
+            Text format.
+        target_nodata (float): If provided, the nodata value of the target
+            raster.
+        fill_value=None (number): If provided, the value that the target raster
+            should be filled with.
+    Returns:
+        ``None``
+    """
+    bbox_minx, bbox_miny, bbox_maxx, bbox_maxy = target_bounding_box
+
+    driver = gdal.GetDriverByName('GTiff')
+    n_bands = 1
+    n_cols = int(numpy.ceil(
+        abs((bbox_maxx - bbox_minx) / target_pixel_size[0])))
+    n_rows = int(numpy.ceil(
+        abs((bbox_maxy - bbox_miny) / target_pixel_size[1])))
+
+    raster = driver.Create(
+        target_raster_path, n_cols, n_rows, n_bands, target_pixel_type,
+        options=['TILED=YES', 'BIGTIFF=YES', 'COMPRESS=DEFLATE',
+                 'BLOCKXSIZE=256', 'BLOCKYSIZE=256'])
+    raster.SetProjection(target_srs_wkt)
+
+    # Set the transform based on the upper left corner and given pixel
+    # dimensions.  Bounding box is in format [minx, miny, maxx, maxy]
+    if target_pixel_size[0] < 0:
+        x_source = bbox_maxx
+    else:
+        x_source = bbox_minx
+    if target_pixel_size[1] < 0:
+        y_source = bbox_maxy
+    else:
+        y_source = bbox_miny
+    raster_transform = [
+        x_source, target_pixel_size[0], 0.0,
+        y_source, 0.0, target_pixel_size[1]]
+    raster.SetGeoTransform(raster_transform)
+
+    # Fill the band if requested.
+    band = raster.GetRasterBand(1)
+    if fill_value is not None:
+        band.Fill(fill_value)
+
+    # Set the nodata value.
+    if target_nodata is not None:
+        band.SetNoDataValue(float(target_nodata))
+
+    band = None
+    raster = None
+
+
 def interpolate_points(
         base_vector_path, vector_attribute_field, target_raster_path_band,
         interpolation_mode):

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1079,16 +1079,17 @@ def create_raster_from_vector_extents(
 
 
 def create_raster_from_bounding_box(
-        target_raster_path, target_bounding_box, target_pixel_size,
+        target_bounding_box, target_raster_path, target_pixel_size,
         target_pixel_type, target_srs_wkt, target_nodata=None,
         fill_value=None):
     """Create a raster from a given bounding box.
+
     Args:
-        target_raster_path (string): The path to where the new raster should be
-            created on disk.
         target_bounding_box (tuple): a 4-element iterable of (minx, miny,
             maxx, maxy) in projected units matching the SRS of
             ``target_srs_wkt``.
+        target_raster_path (string): The path to where the new raster should be
+            created on disk.
         target_pixel_size (tuple): A 2-element tuple of the (x, y) pixel size
             of the target raster.  Elements are in units of the target SRS.
         target_pixel_type (int): The GDAL GDT_* type of the target raster.
@@ -1098,9 +1099,15 @@ def create_raster_from_bounding_box(
             raster.
         fill_value=None (number): If provided, the value that the target raster
             should be filled with.
+
     Returns:
         ``None``
     """
+    if target_pixel_type not in _VALID_GDAL_TYPES:
+        raise ValueError(
+            f'Invalid target type, should be a gdal.GDT_* type, received '
+            f'"{target_pixel_type}"')
+
     bbox_minx, bbox_miny, bbox_maxx, bbox_maxy = target_bounding_box
 
     driver = gdal.GetDriverByName('GTiff')

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1103,7 +1103,7 @@ def create_raster_from_bounding_box(
     raster.SetProjection(target_srs_wkt)
 
     # Set the transform based on the upper left corner and given pixel
-    # dimensions.  Bounding box is in format [minx, miny, maxx, maxy]
+    # dimensions.
     x_source = bbox_maxx if target_pixel_size[0] < 0 else bbox_minx
     y_source = bbox_maxy if target_pixel_size[1] < 0 else bbox_miny
     raster_transform = [

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1029,12 +1029,14 @@ def create_raster_from_vector_extents(
                 LOGGER.warning(error)
         layer = None
 
+    target_srs_wkt = vector.GetLayer(0).GetSpatialRef().ExportToWkt()
+    vector = None
+
     if shp_extent is None:
         raise ValueError(
             f'the vector at {base_vector_path} has no geometry, cannot '
             f'create a raster from these extents')
 
-    target_srs_wkt = vector.GetLayer(0).GetSpatialRef().ExportToWkt()
     create_raster_from_bounding_box(
         target_bounding_box=[
             shp_extent[0], shp_extent[2], shp_extent[1], shp_extent[3]

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1104,14 +1104,8 @@ def create_raster_from_bounding_box(
 
     # Set the transform based on the upper left corner and given pixel
     # dimensions.  Bounding box is in format [minx, miny, maxx, maxy]
-    if target_pixel_size[0] < 0:
-        x_source = bbox_maxx
-    else:
-        x_source = bbox_minx
-    if target_pixel_size[1] < 0:
-        y_source = bbox_maxy
-    else:
-        y_source = bbox_miny
+    x_source = bbox_maxx if target_pixel_size[0] < 0 else bbox_minx
+    y_source = bbox_maxy if target_pixel_size[1] < 0 else bbox_miny
     raster_transform = [
         x_source, target_pixel_size[0], 0,
         y_source, 0, target_pixel_size[1]]

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2649,6 +2649,28 @@ class TestGeoprocessing(unittest.TestCase):
         result = pygeoprocessing.raster_to_numpy_array(target_raster_path)
         numpy.testing.assert_array_equal(expected_result, result)
 
+    def test_create_raster_from_bounding_box(self):
+        """PGP.geoprocessing: test create raster from bbox."""
+        bbox = [_DEFAULT_ORIGIN[0], _DEFAULT_ORIGIN[1],
+                _DEFAULT_ORIGIN[0] + 100, _DEFAULT_ORIGIN[1] + 150]
+        target_srs = osr.SpatialReference()
+        target_srs.ImportFromEPSG(_DEFAULT_EPSG)
+        target_wkt = target_srs.ExportToWkt()
+
+        target_raster_path = os.path.join(self.workspace_dir, 'raster.tif')
+        target_nodata = -12345
+        fill_value = 5678
+        pixel_size = (10, -10)
+        pygeoprocessing.create_raster_from_bounding_box(
+            bbox, target_raster_path, pixel_size, gdal.GDT_Int32,
+            target_wkt, target_nodata=target_nodata, fill_value=fill_value)
+
+        info = pygeoprocessing.get_raster_info(target_raster_path)
+        self.assertEqual(info['pixel_size'], pixel_size)
+        self.assertEqual(info['raster_size'], (10, 15))
+        self.assertEqual(info['nodata'], [target_nodata])
+        self.assertEqual(info['datatype'], gdal.GDT_Int32)
+
     def test_transform_box(self):
         """PGP.geoprocessing: test geotransforming lat/lng box to UTM10N."""
         # Willamette valley in lat/lng

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2652,7 +2652,7 @@ class TestGeoprocessing(unittest.TestCase):
     def test_create_raster_from_bounding_box(self):
         """PGP.geoprocessing: test create raster from bbox."""
         bbox = [_DEFAULT_ORIGIN[0], _DEFAULT_ORIGIN[1],
-                _DEFAULT_ORIGIN[0] + 100, _DEFAULT_ORIGIN[1] + 150]
+                _DEFAULT_ORIGIN[0] + 100, _DEFAULT_ORIGIN[1] + 145]
         target_srs = osr.SpatialReference()
         target_srs.ImportFromEPSG(_DEFAULT_EPSG)
         target_wkt = target_srs.ExportToWkt()


### PR DESCRIPTION
This PR adds a new function, `pygeoprocessing.create_raster_from_bounding_box` and refactors `pygeoprocessing.create_raster_from_vector_extents` to use the new function.

Since `create_raster_from_vector_extents` already has extensive functional tests, I just added a test to ensure that the new entrypoint works as expected.

Fixes #276 