### PR TITLE
Add a function to build overviews

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,8 @@ Release History
 
 Unreleased Changes
 ------------------
-* Added a function to build overviews for a raster. Related to this,
+* Added a function to build overviews for a raster,
+  ``pygeoprocessing.build_overviews``. Related to this,
   ``pygeoprocessing.get_raster_info()`` now includes an ``'overviews'`` key
   listing the pixel dimensions of each overview layer in a raster.
   https://github.com/natcap/pygeoprocessing/issues/280

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@ Release History
 
 Unreleased Changes
 ------------------
+* Added a function to build overviews for a raster. Related to this,
+  ``pygeoprocessing.get_raster_info()`` now includes an ``'overviews'`` key
+  listing the pixel dimensions of each overview layer in a raster.
+  https://github.com/natcap/pygeoprocessing/issues/280
 * Win32 wheels of PyGeoprocessing are no longer created through our GitHub
   Actions workflows and will no longer be produced or distributed as part of
   our release checklist.  For details (and metrics!) see:

--- a/src/pygeoprocessing/__init__.py
+++ b/src/pygeoprocessing/__init__.py
@@ -11,6 +11,7 @@ import pkg_resources.extern.packaging.version
 from . import geoprocessing
 from .geoprocessing import _assert_is_valid_pixel_size
 from .geoprocessing import align_and_resize_raster_stack
+from .geoprocessing import build_overviews
 from .geoprocessing import calculate_disjoint_polygon_set
 from .geoprocessing import convolve_2d
 from .geoprocessing import create_raster_from_vector_extents

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -4110,7 +4110,7 @@ def build_overviews(raster_path_band_tuple, internal=False,
 
     LOGGER.debug(f"Using overviews {overview_scales}")
     result = raster.BuildOverviews(
-        pszResampling=resample_method,
+        resampling=resample_method,
         overviewlist=overview_scales,
         callback=overviews_progress
     )

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2197,7 +2197,8 @@ def warp_raster(
 
     if resample_method.lower() not in _GDAL_WARP_ALGORITHMS:
         raise ValueError(
-            f'Invalid resample method: "{resample_method}"')
+            f'Invalid resample method: "{resample_method}". '
+            f'Must be one of {_GDAL_WARP_ALGOS_FOR_HUMAN_EYES}')
 
     gdal.Warp(
         warped_raster_path, base_raster,
@@ -4177,7 +4178,8 @@ def build_overviews(
     """
     if resample_method.lower() not in _GDAL_WARP_ALGORITHMS:
         raise ValueError(
-            f'Invalid overview resample method: "{resample_method}"')
+            f'Invalid overview resample method: "{resample_method}". '
+            f'Must be one of {_GDAL_WARP_ALGOS_FOR_HUMAN_EYES}')
 
     def overviews_progress(*args, **kwargs):
         pct_complete, name, other = args

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -4070,7 +4070,6 @@ def build_overviews(raster_path_band_tuple, internal=False,
     if not _is_raster_path_band_formatted(raster_path_band_tuple):
         raise ValueError(
             "Expected raster path/band tuple for "
-
             f"raster_path_band_tuple but got {raster_path_band_tuple}")
     # WarpOptions.this is None when an invalid option is passed, and it's a
     # truthy SWIG proxy object when it's given a valid resample arg.

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -4067,6 +4067,22 @@ def stitch_rasters(
 
 def build_overviews(raster_path_band_tuple, internal=False,
                     resample_method='nearest', overwrite=False):
+    """Build overviews for a raster dataset.
+
+    Args:
+        raster_path_band_tuple (tuple): A path/band tuple of the path to the
+            raster on disk and the band index to build overviews for.
+        internal=False (bool): Whether to modify the raster when building
+            overviews. In GeoTiffs, this builds internal overviews when
+            ``internal=True``, and external overviews when ``internal=False``.
+        resample_method='nearest' (str): The resample method to use when
+            building overviews.
+        overwrite=False (bool): Whether to overwrite existing overviews, if
+            any exist.
+
+    Returns:
+        ``None``
+    """
     if not _is_raster_path_band_formatted(raster_path_band_tuple):
         raise ValueError(
             "Expected raster path/band tuple for "

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1649,6 +1649,10 @@ def get_raster_info(raster_path):
           efficient reading.
         * ``'numpy_type'`` (numpy type): this is the equivalent numpy datatype
           for the raster bands including signed bytes.
+        * ``'overviews'`` (sequence): A list of (x, y) tuples for the
+          number of pixels in the width and height of each overview level of
+          the raster.
+        * ``'file_list'`` (sequence): A list of files that make up this raster.
 
     """
     raster = gdal.OpenEx(raster_path, gdal.OF_RASTER)
@@ -1671,6 +1675,15 @@ def get_raster_info(raster_path):
     raster_properties['nodata'] = [
         raster.GetRasterBand(index).GetNoDataValue() for index in range(
             1, raster_properties['n_bands']+1)]
+
+    # GDAL creates overviews for the whole raster but has overviews accessed
+    # per band.  We assume that all bands have the same overviews.
+    raster_properties['overviews'] = []
+    for overview_index in range(raster.GetRasterBand(1).GetOverviewCount()):
+        overview_band = raster.GetRasterBand(1).GetOverview(overview_index)
+        raster_properties['overviews'].append((
+            overview_band.XSize, overview_band.YSize))
+
     # blocksize is the same for all bands, so we can just get the first
     raster_properties['block_size'] = raster.GetRasterBand(1).GetBlockSize()
 

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -4084,8 +4084,8 @@ def build_overviews(
     """Build overviews for a raster dataset.
 
     Args:
-        raster_path (str): A path to a raster on disk and the band index to
-            build overviews for.
+        raster_path (str): A path to a raster on disk for which overviews
+            should be built.
         internal=False (bool): Whether to modify the raster when building
             overviews. In GeoTiffs, this builds internal overviews when
             ``internal=True``, and external overviews when ``internal=False``.
@@ -4126,7 +4126,6 @@ def build_overviews(
             overviews_progress.last_progress_report = time.time()
     overviews_progress.last_progress_report = time.time()
 
-    raster_path = raster_path
     open_flags = gdal.OF_RASTER
     if internal:
         open_flags |= gdal.GA_Update

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -4175,8 +4175,6 @@ def build_overviews(
     Returns:
         ``None``
     """
-    # WarpOptions.this is None when an invalid option is passed, and it's a
-    # truthy SWIG proxy object when it's given a valid resample arg.
     if resample_method.lower() not in _GDAL_WARP_ALGORITHMS:
         raise ValueError(
             f'Invalid overview resample method: "{resample_method}"')

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -94,8 +94,9 @@ for _warp_algo in (_attrname for _attrname in dir(gdalconst)
                      resampleAlg=getattr(gdalconst, _warp_algo))
 _GDAL_WARP_ALGORITHMS = set(_GDAL_WARP_ALGORITHMS)
 _GDAL_WARP_ALGORITHMS.discard('-r')
+_GDAL_WARP_ALGOS_FOR_HUMAN_EYES = "|".join(_GDAL_WARP_ALGORITHMS)
 LOGGER.debug(
-    f'Detected warp algorithms: {", ".join(_GDAL_WARP_ALGORITHMS)}')
+    f'Detected warp algorithms: {", ".join(_GDAL_WARP_ALGOS_FOR_HUMAN_EYES)}')
 
 
 def raster_calculator(
@@ -1984,7 +1985,7 @@ def warp_raster(
         gdal_warp_options=None, working_dir=None,
         raster_driver_creation_tuple=DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS,
         osr_axis_mapping_strategy=DEFAULT_OSR_AXIS_MAPPING_STRATEGY):
-    """Resize/resample raster to desired pixel size, bbox and projection.
+    f"""Resize/resample raster to desired pixel size, bbox and projection.
 
     Args:
         base_raster_path (string): path to base raster.
@@ -1993,7 +1994,7 @@ def warp_raster(
         target_raster_path (string): the location of the resized and
             resampled raster.
         resample_method (string): the resampling technique, one of
-            ``near|bilinear|cubic|cubicspline|lanczos|average|mode|max|min|med|q1|q3``
+            ``{_GDAL_WARP_ALGOS_FOR_HUMAN_EYES}``
         target_bb (sequence): if None, target bounding box is the same as the
             source bounding box.  Otherwise it's a sequence of float
             describing target bounding box in target coordinate system as
@@ -3799,7 +3800,7 @@ def stitch_rasters(
         overlap_algorithm='etch',
         area_weight_m2_to_wgs84=False,
         osr_axis_mapping_strategy=DEFAULT_OSR_AXIS_MAPPING_STRATEGY):
-    """Stitch the raster in the base list into the existing target.
+    f"""Stitch the raster in the base list into the existing target.
 
     Args:
         base_raster_path_band_list (sequence): sequence of raster path/band
@@ -3807,7 +3808,7 @@ def stitch_rasters(
         resample_method_list (sequence): a sequence of resampling methods
             which one to one map each path in ``base_raster_path_band_list``
             during resizing.  Each element must be one of
-            "near|bilinear|cubic|cubicspline|lanczos|mode".
+            ``{_GDAL_WARP_ALGOS_FOR_HUMAN_EYES}``
         target_stitch_raster_path_band (tuple): raster path/band tuple to an
             existing raster, values in ``base_raster_path_band_list`` will
             be stitched into this raster/band in the order they are in the
@@ -4096,7 +4097,7 @@ def stitch_rasters(
 def build_overviews(
         raster_path, internal=False, resample_method='near',
         overwrite=False, levels='auto'):
-    """Build overviews for a raster dataset.
+    f"""Build overviews for a raster dataset.
 
     Args:
         raster_path (str): A path to a raster on disk for which overviews
@@ -4105,7 +4106,8 @@ def build_overviews(
             overviews. In GeoTiffs, this builds internal overviews when
             ``internal=True``, and external overviews when ``internal=False``.
         resample_method='near' (str): The resample method to use when
-            building overviews.
+            building overviews.  Must be one of
+            ``{_GDAL_WARP_ALGOS_FOR_HUMAN_EYES}``.
         overwrite=False (bool): Whether to overwrite existing overviews, if
             any exist.
         levels='auto' (sequence): A sequence of integer overview levels. If

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -4866,3 +4866,20 @@ class TestGeoprocessing(unittest.TestCase):
             finally:
                 band = None
                 raster = None
+
+        # Test that an error was raised if we try to re-build overviews on a
+        # raster that already has them.
+        with self.assertRaises(ValueError) as cm:
+            pygeoprocessing.build_overviews((raster_path, 1))
+        self.assertIn("Band 1 already has overviews", str(cm.exception))
+
+        # Forcibly overwriting the overviews should work fine, though.
+        pygeoprocessing.build_overviews((raster_path, 1), overwrite=True)
+
+        # Check that we can catch invalid resample methods
+        with self.assertRaises(ValueError) as cm:
+            pygeoprocessing.build_overviews(
+                (raster_path, 1), overwrite=True,
+                resample_method='invalid choice')
+        self.assertIn('Invalid overview resample method: "invalid choice"',
+                      str(cm.exception))

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -4846,7 +4846,8 @@ class TestGeoprocessing(unittest.TestCase):
             _array_to_raster(array, 255, raster_path)
             pygeoprocessing.build_overviews(raster_path,
                                             internal=internal,
-                                            resample_method='nearest')
+                                            resample_method='nearest',
+                                            levels=levels)
 
             # internal overviews mean only 1 file in raster
             self.assertEqual(len(os.listdir(self.workspace_dir)),

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -4833,3 +4833,28 @@ class TestGeoprocessing(unittest.TestCase):
 
         self.assertIn(
             "The fields and attributes for feature 0", str(cm.exception))
+
+    def test_build_overviews_gtiff_internal(self):
+        """PGP: test internal raster overviews."""
+        array = numpy.ones((2000, 1000), dtype=numpy.byte)
+        raster_path = os.path.join(self.workspace_dir, 'raster.tif')
+        _array_to_raster(array, 255, raster_path)
+
+        pygeoprocessing.build_overviews((raster_path, 1), internal=True,
+                                        resample_method='nearest')
+        try:
+            raster = gdal.Open(raster_path)
+            band = raster.GetRasterBand(1)
+            self.assertEqual(band.GetOverviewCount(), 2)
+
+            for ovr_index, (shape_x, shape_y) in enumerate(
+                    [(500, 1000), (250, 500)]):
+                overview = band.GetOverview(ovr_index)
+                self.assertEqual(overview.XSize, shape_x)
+                self.assertEqual(overview.YSize, shape_y)
+                numpy.testing.assert_array_equal(
+                    overview.ReadAsArray(),
+                    numpy.ones((shape_y, shape_x), dtype=array.dtype))
+        finally:
+            band = None
+            raster = None

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -4838,7 +4838,8 @@ class TestGeoprocessing(unittest.TestCase):
         """PGP: test raster overviews."""
         array = numpy.ones((2000, 1000), dtype=numpy.byte)
 
-        for internal, expected_filecount in ((True, 1), (False, 2)):
+        for internal, expected_filecount, levels in (
+                (True, 1, 'auto'), (False, 2, [2, 4])):
             # Rewriting raster on each iteration to ensure we're working with a
             # fresh raster each time.
             raster_path = os.path.join(self.workspace_dir, 'raster.tif')

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -4889,3 +4889,5 @@ class TestGeoprocessing(unittest.TestCase):
             pygeoprocessing.build_overviews(
                 raster_path)
         self.assertIn("Expected raster path/band tuple for", str(cm.exception))
+
+        # TODO: fix the band issue - overviews built for whole raster

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -4843,7 +4843,7 @@ class TestGeoprocessing(unittest.TestCase):
             # fresh raster each time.
             raster_path = os.path.join(self.workspace_dir, 'raster.tif')
             _array_to_raster(array, 255, raster_path)
-            pygeoprocessing.build_overviews((raster_path, 1),
+            pygeoprocessing.build_overviews(raster_path,
                                             internal=internal,
                                             resample_method='nearest')
 
@@ -4870,24 +4870,16 @@ class TestGeoprocessing(unittest.TestCase):
         # Test that an error was raised if we try to re-build overviews on a
         # raster that already has them.
         with self.assertRaises(ValueError) as cm:
-            pygeoprocessing.build_overviews((raster_path, 1))
-        self.assertIn("Band 1 already has overviews", str(cm.exception))
+            pygeoprocessing.build_overviews(raster_path)
+        self.assertIn("Raster already has overviews", str(cm.exception))
 
         # Forcibly overwriting the overviews should work fine, though.
-        pygeoprocessing.build_overviews((raster_path, 1), overwrite=True)
+        pygeoprocessing.build_overviews(raster_path, overwrite=True)
 
         # Check that we can catch invalid resample methods
         with self.assertRaises(ValueError) as cm:
             pygeoprocessing.build_overviews(
-                (raster_path, 1), overwrite=True,
+                raster_path, overwrite=True,
                 resample_method='invalid choice')
         self.assertIn('Invalid overview resample method: "invalid choice"',
                       str(cm.exception))
-
-        # Check that invalid path/band input is handled
-        with self.assertRaises(ValueError) as cm:
-            pygeoprocessing.build_overviews(
-                raster_path)
-        self.assertIn("Expected raster path/band tuple for", str(cm.exception))
-
-        # TODO: fix the band issue - overviews built for whole raster

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -4883,3 +4883,9 @@ class TestGeoprocessing(unittest.TestCase):
                 resample_method='invalid choice')
         self.assertIn('Invalid overview resample method: "invalid choice"',
                       str(cm.exception))
+
+        # Check that invalid path/band input is handled
+        with self.assertRaises(ValueError) as cm:
+            pygeoprocessing.build_overviews(
+                raster_path)
+        self.assertIn("Expected raster path/band tuple for", str(cm.exception))

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -4883,3 +4883,17 @@ class TestGeoprocessing(unittest.TestCase):
                 resample_method='invalid choice')
         self.assertIn('Invalid overview resample method: "invalid choice"',
                       str(cm.exception))
+
+    def test_get_raster_info_overviews(self):
+        """PGP: raster info about overviews."""
+        array = numpy.ones((2000, 1000), dtype=numpy.byte)
+        raster_path = os.path.join(self.workspace_dir, 'raster.tif')
+        _array_to_raster(array, 255, raster_path)
+        pygeoprocessing.build_overviews(
+            raster_path, resample_method='nearest')
+
+        raster_info = pygeoprocessing.get_raster_info(raster_path)
+
+        # The ordering of x, y is reversed from the numpy array shape.
+        self.assertEqual(
+            raster_info['overviews'], [(500, 1000), (250, 500)])

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -4846,7 +4846,7 @@ class TestGeoprocessing(unittest.TestCase):
             _array_to_raster(array, 255, raster_path)
             pygeoprocessing.build_overviews(raster_path,
                                             internal=internal,
-                                            resample_method='nearest',
+                                            resample_method='near',
                                             levels=levels)
 
             # internal overviews mean only 1 file in raster
@@ -4892,7 +4892,7 @@ class TestGeoprocessing(unittest.TestCase):
         raster_path = os.path.join(self.workspace_dir, 'raster.tif')
         _array_to_raster(array, 255, raster_path)
         pygeoprocessing.build_overviews(
-            raster_path, resample_method='nearest')
+            raster_path, resample_method='near')
 
         raster_info = pygeoprocessing.get_raster_info(raster_path)
 


### PR DESCRIPTION
This PR adds a function to build overviews with a couple of parameters:

* Whether the overviews should be internal or external
* The resampling algorithm to use
* Whether to overwrite existing overviews if they exist
* The overview levels to use, or if the function should just generate a bunch of them.

In addition to having a function to build overviews, I also extended `get_raster_info()` to include a new `overviews` key that lists the dimensions of the overviews.  This is similar to what we see in the output of `gdalinfo`.  I also added another missing `file_list` parameter that was present in `get_raster_info()`'s output but not in the docstring.

Fixes #280 