### PR TITLE
Add `isnan()` checking to routing's`_is_close()`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@ Release History
 
 Unreleased Changes
 ------------------
+* Nodata value checking in ``pygeoprocessing.routing`` now correctly handles
+  comparison of ``nan`` values.  This is explicitly tested in
+  ``pygeoprocessing.routing.fill_pits``, but should also improve the
+  experience of other routing functions as well.
+  https://github.com/natcap/pygeoprocessing/issues/248
 * Added a function to build overviews for a raster,
   ``pygeoprocessing.build_overviews``. Related to this,
   ``pygeoprocessing.get_raster_info()`` now includes an ``'overviews'`` key

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -31,6 +31,7 @@ from cython.operator cimport dereference as deref
 from cython.operator cimport preincrement as inc
 from libc.time cimport time as ctime
 from libc.time cimport time_t
+from libc.math cimport isnan
 from libcpp.deque cimport deque
 from libcpp.list cimport list as clist
 from libcpp.pair cimport pair
@@ -182,6 +183,8 @@ cdef cppclass GreaterPixel nogil:
         return 0
 
 cdef int _is_close(double x, double y, double abs_delta, double rel_delta):
+    if isnan(x) and isnan(y):
+        return 1
     return abs(x-y) <= (abs_delta+rel_delta*abs(y))
 
 # a class to allow fast random per-pixel access to a raster for both setting

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -149,6 +149,26 @@ class TestRouting(unittest.TestCase):
         dem_array[3:8, 3:8] = 0.0
         numpy.testing.assert_almost_equal(result_array, dem_array)
 
+    def test_pit_filling_nodata_nan(self):
+        """PGP.routing: test pitfilling with nan nodata value."""
+        base_path = os.path.join(self.workspace_dir, 'base.tif')
+        dem_array = numpy.zeros((11, 11), dtype=numpy.float32)
+        nodata = numpy.nan
+        dem_array[3:8, 3:8] = -1
+        dem_array[0, 0] = -1
+        dem_array[1, 1] = nodata
+        _array_to_raster(dem_array, nodata, base_path)
+
+        fill_path = os.path.join(self.workspace_dir, 'filled.tif')
+        pygeoprocessing.routing.fill_pits(
+            (base_path, 1), fill_path, working_dir=self.workspace_dir)
+
+        result_array = pygeoprocessing.raster_to_numpy_array(fill_path)
+        self.assertEqual(result_array.dtype, numpy.float32)
+        # the expected result is that the pit is filled in
+        dem_array[3:8, 3:8] = 0.0
+        numpy.testing.assert_almost_equal(result_array, dem_array)
+
     def test_flow_dir_d8(self):
         """PGP.routing: test D8 flow."""
         dem_path = os.path.join(self.workspace_dir, 'dem.tif')


### PR DESCRIPTION
This PR adds support for IEEE754 `nan` values to our routing `_is_close()` function, which is exclusively used in `pygeoprocessing.routing` to check nodata values.

The addition of `isnan` should not incur a significant cost as [the glibc implementation I found online](https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/ieee754/dbl-64/s_isnan.c;h=1f1535dea33e99520e13717ab57f5c9a7f6509c1;hb=HEAD) has no branching at all and is mostly bitshifting -- cheap for hardware.  Even then, only 1 value will need to be checked for `nan`-ness before it falls back to the usual arithmetic of `_is_close()`.  The benefit for this small cost, that we shouldn't have to address this again on the forums(!), at least for pitfilling, should be great.

Fixes #248