### PR TITLE
Allow user-defined target layer name in `reproject_vector`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@ Release History
 
 Unreleased Changes
 ------------------
+* The function ``pygeoprocessing.reproject_vector`` now accepts an optional
+  parameter ``layer_name`` to allow the target vector layer name to be defined
+  by the user.  If the user does not provide a ``layer_name``, the layer name
+  will be copied from the source vector.
+  https://github.com/natcap/pygeoprocessing/issues/301
 * Implement the proposed new function ``pygeoprocessing.raster_reduce``, a
   wrapper around ``pygeoprocessing.iterblocks``
    (https://github.com/natcap/pygeoprocessing/issues/285)

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1891,7 +1891,12 @@ def reproject_vector(
     """Reproject OGR DataSource (vector).
 
     Transforms the features of the base vector to the desired output
-    projection in a new ESRI Shapefile.
+    projection in a new vector.
+
+    Note:
+        If the ESRI Shapefile driver is used, the ``target_layer_name``
+        optional parameter is ignored. ESRI Shapefiles by definition use the
+        filename to define the layer name.
 
     Args:
         base_vector_path (string): Path to the base shapefile to transform.
@@ -1915,7 +1920,7 @@ def reproject_vector(
             ``geoprocessing.DEFAULT_OSR_AXIS_MAPPING_STRATEGY``. This parameter
             should not be changed unless you know what you are doing.
 
-    Return:
+    Returns:
         None
     """
     base_vector = gdal.OpenEx(base_vector_path, gdal.OF_VECTOR)


### PR DESCRIPTION
This PR allows the user to define a target layer name when reprojecting a vector.  A special case has been implemented to handle the case of an ESRI Shapefile, where the layer name matches the filename and cannot be defined by hand.

Fixes #301 