### PR TITLE
Add a library of convolution kernels

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,15 @@ Release History
 
 Unreleased Changes
 ------------------
+* A new submodule, ``pygeoprocessing.kernels`` has been added to facilitate the
+  creation of kernel rasters needed for calls to
+  ``pygeoprocessing.convolve_2d``. Functions for creating common decay kernels
+  have been added, along with functions to facilitate the creation of
+  distance-based kernels using a user-defined function
+  (``pygeoprocessing.create_kernel``) and to facilitate the creation of kernels
+  using custom 2D numpy arrays, such as those commonly used in image processing
+  (``pygeoprocessing.kernel_from_numpy_array``).
+  https://github.com/natcap/pygeoprocessing/issues/268
 * The function ``pygeoprocessing.reproject_vector`` now accepts an optional
   parameter ``layer_name`` to allow the target vector layer name to be defined
   by the user.  If the user does not provide a ``layer_name``, the layer name

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
     url='https://github.com/natcap/pygeoprocessing',
     packages=[
         'pygeoprocessing',
-        'pygeoprocessing.kernels',
         'pygeoprocessing.routing',
         'pygeoprocessing.multiprocessing',
     ],

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     url='https://github.com/natcap/pygeoprocessing',
     packages=[
         'pygeoprocessing',
+        'pygeoprocessing.kernels',
         'pygeoprocessing.routing',
         'pygeoprocessing.multiprocessing',
     ],

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -3936,7 +3936,7 @@ def numpy_array_to_raster(
         new_raster.SetProjection(projection_wkt)
     if origin is not None and pixel_size is not None:
         new_raster.SetGeoTransform(
-            [origin[0], pixel_size[0], 0.0, origin[1], 0.0, pixel_size[1]])
+            [origin[0], pixel_size[0], 0, origin[1], 0, pixel_size[1]])
     elif origin is not None or pixel_size is not None:
         raise ValueError(
             "Origin and pixel size must both be defined or both be None")

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2797,7 +2797,9 @@ def convolve_2d(
         kernel_path_band (tuple): a 2 tuple of the form
             (filepath to kernel raster, band index), all pixel values should
             be valid -- output is not well defined if the kernel raster has
-            nodata values.
+            nodata values.  To create a kernel raster, see the documentation
+            and helper functions available in the
+            :doc:`pygeoprocessing kernels module <pygeoprocessing.kernels>`.
         target_path (string): filepath to target raster that's the convolution
             of signal with kernel.  Output will be a single band raster of
             same size and projection as ``signal_path_band``. Any nodata pixels

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -741,7 +741,7 @@ def align_and_resize_raster_stack(
             ``geoprocessing.DEFAULT_OSR_AXIS_MAPPING_STRATEGY``. This parameter
             should not be changed unless you know what you are doing.
 
-    Return:
+    Returns:
         None
 
     Raises:
@@ -765,7 +765,6 @@ def align_and_resize_raster_stack(
             file.
         ValueError
             If ``pixel_size`` is not a 2 element sequence of numbers.
-
     """
     # make sure that the input lists are of the same length
     list_lengths = [
@@ -2854,7 +2853,7 @@ def convolve_2d(
             tuple/list as the second. Defaults to a GTiff driver tuple
             defined at geoprocessing.DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS.
 
-    Return:
+    Returns:
         ``None``
 
     Raises:
@@ -2865,7 +2864,6 @@ def convolve_2d(
             if ``signal_path_band`` or ``kernel_path_band`` is a row based
             blocksize which would result in slow runtimes due to gdal
             cache thrashing.
-
     """
     if target_datatype is not gdal.GDT_Float64 and target_nodata is None:
         raise ValueError(

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -3900,9 +3900,12 @@ def numpy_array_to_raster(
     Args:
         base_array (numpy.array): a 2d numpy array.
         target_nodata (numeric): nodata value of target array, can be None.
-        pixel_size (tuple): square dimensions (in ``(x, y)``) of pixel.
-        origin (tuple/list): x/y coordinate of the raster origin.
-        projection_wkt (str): target projection in wkt.
+        pixel_size (tuple): square dimensions (in ``(x, y)``) of pixel. Can be
+            None to indicate no stated pixel size.
+        origin (tuple/list): x/y coordinate of the raster origin. Can be None
+            to indicate no stated origin.
+        projection_wkt (str): target projection in wkt.  Can be None to
+            indicate no projection/SRS.
         target_path (str): path to raster to create that will be of the
             same type of base_array with contents of base_array.
         raster_driver_creation_tuple (tuple): a tuple containing a GDAL driver
@@ -3933,8 +3936,12 @@ def numpy_array_to_raster(
         options=raster_driver_creation_tuple[1])
     if projection_wkt is not None:
         new_raster.SetProjection(projection_wkt)
-    new_raster.SetGeoTransform(
-        [origin[0], pixel_size[0], 0.0, origin[1], 0.0, pixel_size[1]])
+    if origin is not None and pixel_size is not None:
+        new_raster.SetGeoTransform(
+            [origin[0], pixel_size[0], 0.0, origin[1], 0.0, pixel_size[1]])
+    elif origin is not None or pixel_size is not None:
+        raise ValueError(
+            "Origin and pixel size must both be defined or both be None")
     new_band = new_raster.GetRasterBand(1)
     if target_nodata is not None:
         new_band.SetNoDataValue(target_nodata)

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -3897,6 +3897,14 @@ def numpy_array_to_raster(
         raster_driver_creation_tuple=DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS):
     """Create a single band raster of size ``base_array.shape``.
 
+    The GDAL datatype of the target raster is determined by the numpy dtype of
+    ``base_array``.
+
+    Note:
+        The ``origin`` and ``pixel_size`` parameters must both be defined
+        properly as 2-tuples of floats, or else must both be set to ``None``.
+        A ``ValueError`` will be raised otherwise.
+
     Args:
         base_array (numpy.array): a 2d numpy array.
         target_nodata (numeric): nodata value of target array, can be None.

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -61,14 +61,11 @@ def dichotomous_kernel(target_kernel_path, max_distance, normalize):
 # UNA calls this a density kernel
 # really, this is quite specific to UNA
 def parabolic_decay_kernel(target_kernel_path, max_distance, normalize=True):
-    """Create an inverted parabola that reaches a value of 0 at ``max_distance``
-
+    """Create an inverted parabola that reaches 0 at ``max_distance``
     """
-    def _density(dist):
-        return (0.75 * (1 - (dist / max_distance) ** 2))
-
     create_kernel(
-        target_kernel_path, _density, max_distance, normalize=normalize)
+        target_kernel_path, "0.75 * (1-(dist / max_dist) ** 2)",
+        max_distance, normalize=normalize)
 
 
 def numexpr_kernel(target_kernel_path, max_distance, expression, extras=None):
@@ -82,20 +79,16 @@ def numexpr_kernel(target_kernel_path, max_distance, expression, extras=None):
 
 
 def exponential_decay_kernel(target_kernel_path, max_distance,
-                             distance_factor=1, normalize=True):
-    def _exp_decay(dist):
-        return numpy.exp(-(dist*distance_factor) / max_distance)
-
+                             normalize=True):
     create_kernel(
-        target_kernel_path, _exp_decay, max_distance, normalize=normalize)
+        target_kernel_path, "exp(-dist / max_dist)",
+        max_distance, normalize=normalize)
 
 
 def linear_decay_kernel(target_kernel_path, max_distance, normalize=True):
-    def _linear_decay(dist):
-        return (max_distance - dist) / max_distance
-
     create_kernel(
-        target_kernel_path, _linear_decay, max_distance, normalize=normalize)
+        target_kernel_path, "(max_dist - dist) / max_dist",
+        max_distance, normalize=normalize)
 
 
 def gaussian_decay_kernel(target_kernel_path, sigma, n_std_dev=3,

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -65,10 +65,10 @@ def parabolic_decay_kernel(target_kernel_path, max_distance, **kwargs):
         max_distance, **kwargs)
 
 
-def exponential_decay_kernel(target_kernel_path, max_distance,
-                             **kwargs):
+def exponential_decay_kernel(target_kernel_path, expected_distance,
+                             max_distance, **kwargs):
     create_kernel(
-        target_kernel_path, "exp(-dist / max_dist)",
+        target_kernel_path, f"exp(-dist / {expected_distance})",
         max_distance, **kwargs)
 
 

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -1,0 +1,99 @@
+import logging
+import math
+
+import numpy
+import pygeoprocessing
+from osgeo import gdal
+from osgeo import osr
+
+FLOAT32_NODATA = numpy.finfo(numpy.float32).min
+LOGGER = logging.getLogger(__name__)
+
+
+def _create_distance_based_kernel(
+        target_kernel_path, function, max_distance, normalize):
+    """
+    Create a kernel raster based on pixel distance from the centerpoint.
+
+    Args:
+        target_kernel_path (string): The path to where the target kernel should
+            be written on disk.  If this file does not have the suffix
+            ``.tif``, it will be added to the filepath.
+        function (callable): A python callable that takes as input a
+            2D numpy array and returns a 2D numpy array.  The input array will
+            contain float32 distances to the centerpoint pixel of the kernel.
+        max_distance (float): The maximum distance of kernel values from
+            the center point.  Values outside of this distance will be set to
+            ``0.0``.
+        normalize (bool): Whether to normalize the resulting kernel.
+
+    Returns:
+        ``None``
+    """
+    pixel_radius = math.ceil(max_distance)
+    kernel_size = pixel_radius * 2 + 1  # allow for a center pixel
+    driver = gdal.GetDriverByName('GTiff')
+    kernel_dataset = driver.Create(
+        target_kernel_path.encode('utf-8'), kernel_size, kernel_size, 1,
+        gdal.GDT_Float32, options=[
+            'BIGTIFF=IF_SAFER', 'TILED=YES', 'BLOCKXSIZE=256',
+            'BLOCKYSIZE=256'])
+
+    # Make some kind of geotransform, it doesn't matter what but
+    # will make GIS libraries behave better if it's all defined
+    kernel_dataset.SetGeoTransform([0, 1, 0, 0, 0, -1])
+    srs = osr.SpatialReference()
+    srs.SetWellKnownGeogCS('WGS84')
+    kernel_dataset.SetProjection(srs.ExportToWkt())
+
+    kernel_band = kernel_dataset.GetRasterBand(1)
+    kernel_nodata = FLOAT32_NODATA
+    kernel_band.SetNoDataValue(kernel_nodata)
+
+    kernel_band = None
+    kernel_dataset = None
+
+    kernel_raster = gdal.OpenEx(target_kernel_path, gdal.GA_Update)
+    kernel_band = kernel_raster.GetRasterBand(1)
+    band_x_size = kernel_band.XSize
+    band_y_size = kernel_band.YSize
+    running_sum = 0
+    for block_data in pygeoprocessing.iterblocks(
+            (target_kernel_path, 1), offset_only=True):
+        array_xmin = block_data['xoff'] - pixel_radius
+        array_xmax = min(
+            array_xmin + block_data['win_xsize'],
+            band_x_size - pixel_radius)
+        array_ymin = block_data['yoff'] - pixel_radius
+        array_ymax = min(
+            array_ymin + block_data['win_ysize'],
+            band_y_size - pixel_radius)
+
+        pixel_dist_from_center = numpy.hypot(
+            *numpy.mgrid[
+                array_ymin:array_ymax,
+                array_xmin:array_xmax])
+        kernel = function(pixel_dist_from_center)
+        running_sum += kernel.sum()
+        kernel_band.WriteArray(
+            kernel,
+            yoff=block_data['yoff'],
+            xoff=block_data['xoff'])
+
+    kernel_raster.FlushCache()
+    kernel_band = None
+    kernel_raster = None
+
+    if normalize:
+        kernel_raster = gdal.OpenEx(target_kernel_path, gdal.GA_Update)
+        kernel_band = kernel_raster.GetRasterBand(1)
+        for block_data, kernel_block in pygeoprocessing.iterblocks(
+                (target_kernel_path, 1)):
+            # divide by sum to normalize
+            kernel_block /= running_sum
+            kernel_band.WriteArray(
+                kernel_block, xoff=block_data['xoff'], yoff=block_data['yoff'])
+
+        kernel_raster.FlushCache()
+        kernel_band = None
+        kernel_raster = None

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -71,7 +71,6 @@ def kernel_from_numpy_array(
 def dichotomous_kernel(
         target_kernel_path: Text,
         max_distance: Union[int, float],
-        apothem: Union[int, float] = None,
         normalize: bool = True) -> None:
     """Create a binary kernel indicating presence/absence within a distance.
 
@@ -85,8 +84,6 @@ def dichotomous_kernel(
         max_distance: The distance threshold, in pixels. Kernel
             pixels that are greater than ``max_distance`` from the centerpoint
             of the kernel will have values of ``0.0``.
-        apothem: The apothem of the target kernel, in pixels.  If ``None``,
-            then ``math.ceil(max_distance)`` will be used.
         normalize: Whether to normalize the kernel.
 
     Returns:
@@ -99,7 +96,6 @@ def dichotomous_kernel(
         target_kernel_path=target_kernel_path,
         distance_decay_function=_dichotomous,
         max_distance=max_distance,
-        apothem=apothem,
         normalize=normalize
     )
 
@@ -108,7 +104,6 @@ def exponential_decay_kernel(
         target_kernel_path: Text,
         max_distance: Union[int, float],
         expected_distance: Union[int, float],
-        apothem: Union[int, float] = None,
         normalize: bool = True) -> None:
     """Create an exponential decay kernel.
 
@@ -127,8 +122,6 @@ def exponential_decay_kernel(
             of the kernel will have values of ``0.0``.
         expected_distance: The distance, in pixels, from the centerpoint at
             which decayed values will equal ``1/e``.
-        apothem: The apothem of the target kernel, in pixels.  If ``None``,
-            then ``math.ceil(max_distance)`` will be used.
         normalize: Whether to normalize the kernel.
 
     Returns:
@@ -141,7 +134,6 @@ def exponential_decay_kernel(
         target_kernel_path=target_kernel_path,
         distance_decay_function=_exponential_decay,
         max_distance=max_distance,
-        apothem=apothem,
         normalize=normalize
     )
 
@@ -149,7 +141,6 @@ def exponential_decay_kernel(
 def linear_decay_kernel(
         target_kernel_path: Text,
         max_distance: Union[int, float],
-        apothem: Union[int, float] = None,
         normalize: bool = True) -> None:
     """Create a linear decay kernel.
 
@@ -164,8 +155,6 @@ def linear_decay_kernel(
         max_distance: The maximum distance of the kernel, in pixels. Kernel
             pixels that are greater than ``max_distance`` from the centerpoint
             of the kernel will have values of ``0.0``.
-        apothem: The apothem of the target kernel, in pixels.  If ``None``,
-            then ``math.ceil(max_distance)`` will be used.
         normalize: Whether to normalize the kernel.
 
     Returns:
@@ -178,7 +167,6 @@ def linear_decay_kernel(
         target_kernel_path=target_kernel_path,
         distance_decay_function=_linear_decay,
         max_distance=max_distance,
-        apothem=apothem,
         normalize=normalize
     )
 
@@ -223,7 +211,6 @@ def create_distance_decay_kernel(
         target_kernel_path: str,
         distance_decay_function: Union[str, Callable],
         max_distance: Union[int, float],
-        apothem=None,
         normalize=True):
     """
     Create a kernel raster based on pixel distance from the centerpoint.
@@ -245,19 +232,12 @@ def create_distance_decay_kernel(
         max_distance (float): The maximum distance of kernel values from
             the center point.  Values outside of this distance will be set to
             ``0.0``.
-        apothem=None (float): The apothem (in pixels) of the target kernel.
-            If ``None``, the apothem will be ``math.floor(max_distance)``.
         normalize=False (bool): Whether to normalize the resulting kernel.
 
     Returns:
         ``None``
     """
-    if apothem is None:
-        apothem = max_distance
-    if max_distance > apothem:
-        raise AssertionError(
-            "max_distance must be less than or equal to the apothem.")
-    apothem = math.floor(apothem)
+    apothem = math.floor(max_distance)
     kernel_size = apothem * 2 + 1  # allow for a center pixel
     assert kernel_size % 2 == 1
     driver = gdal.GetDriverByName('GTiff')

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -43,9 +43,9 @@ def dichotomous_kernel(
         normalize: bool = True) -> None:
     """Create a binary kernel indicating presence/absence within a distance.
 
-    Given a centerpoint pixel C and an arbitrary pixel P in the target kernel,
-    if the distance between C and P exceeds ``max_distance``, the value of P
-    will be 0.  The value of P will be 1 otherwise.
+    This is equivalent to ``int(dist <= max_distance)`` for each pixel in the
+    kernel, where ``dist`` is the euclidean distance of the pixel's centerpoint
+    to the centerpoint of the center pixel.
 
     Args:
         target_kernel_path: The path to where the kernel will be written.
@@ -80,8 +80,12 @@ def exponential_decay_kernel(
         normalize: bool = True) -> None:
     """Create an exponential decay kernel.
 
-    This kernel will reach 1/e at ``expected_distance``, but will continue to
-    have nonzero values out to ``max_distance``.
+    This is equivalent to ``e**(-dist / expected_distance)`` for each pixel in
+    the kernel, where ``dist`` is the euclidean distance of the pixel's
+    centerpoint to the centerpoint of the center pixel and
+    ``expected_distance`` represents the distance at which the kernel's values
+    reach ``1/e``.  The kernel will continue to have nonzero values out to
+    ``max_distance``.
 
     Args:
         target_kernel_path: The path to where the kernel will be written.
@@ -117,6 +121,11 @@ def linear_decay_kernel(
         normalize: bool = True) -> None:
     """Create a linear decay kernel.
 
+    This is equivalent to ``(max_distance - dist) / max_distance`` for each
+    pixel in the kernel, where ``dist`` is the euclidean distance between the
+    centerpoint of the current pixel and the centerpoint of the center pixel in
+    the kernel.
+
     Args:
         target_kernel_path: The path to where the kernel will be written.
             Must have a file extension of ``.tif``.
@@ -135,7 +144,7 @@ def linear_decay_kernel(
 
     create_distance_decay_kernel(
         target_kernel_path=target_kernel_path,
-        distance_decay_function="(max_dist - dist) / max_dist",
+        distance_decay_function=_linear_decay,
         max_distance=max_distance,
         pixel_radius=pixel_radius,
         normalize=normalize
@@ -149,6 +158,11 @@ def normal_distribution_kernel(
         pixel_radius: Union[int, float] = None,
         normalize: bool = True):
     """Create an decay kernel following a normal distribution.
+
+    This is equivalent to
+    ``(1/(2*pi*sigma**2))*(e**((-dist**2)/(2*sigma**2)))`` for each pixel,
+    where ``dist`` is the euclidean distance between the current pixel and the
+    centerpoint of the center pixel.
 
     Args:
         target_kernel_path: The path to where the kernel will be written.
@@ -190,9 +204,10 @@ def create_distance_decay_kernel(
         target_kernel_path (string): The path to where the target kernel should
             be written on disk.  If this file does not have the suffix
             ``.tif``, it will be added to the filepath.
-        distance_decay_function (callable): A python callable that takes as input a
-            1D numpy array and returns a 1D numpy array.  The input array will
-            contain float32 distances to the centerpoint pixel of the kernel.
+        distance_decay_function (callable): A python callable that takes as
+            input a single 1D numpy array and returns a 1D numpy array.  The
+            input array will contain float32 distances to the centerpoint pixel
+            of the kernel, in units of pixels.
         max_distance (float): The maximum distance of kernel values from
             the center point.  Values outside of this distance will be set to
             ``0.0``.

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -6,6 +6,7 @@ from typing import Union
 
 import numpy
 import pygeoprocessing
+from numpy.typing import ArrayLike
 from osgeo import gdal
 
 FLOAT32_NODATA = float(numpy.finfo(numpy.float32).min)
@@ -19,9 +20,24 @@ LOGGER = logging.getLogger(__name__)
 # TODO: use type hints for these modules and note it in the changelog.
 
 
-def kernel_from_numpy_array(numpy_array, target_kernel_path):
+def kernel_from_numpy_array(
+        numpy_array: ArrayLike, target_kernel_path: Text) -> None:
     """Create a convolution kernel from a numpy array.
+
+    Args:
+        numpy_array: A 2-dimensional numpy array to convert into a raster.
+        target_kernel_path: The path to where the kernel should be written.
+
+    Returns:
+        ``None``
     """
+    n_dimensions = numpy.array(numpy_array).ndim
+    if n_dimensions != 2:
+        raise ValueError(
+            "The kernel array must have exactly 2 dimensions, not "
+            f"{n_dimensions}")
+
+    # The kernel is technically a TIFF, not a GeoTiff.
     pygeoprocessing.numpy_array_to_raster(
         numpy_array, target_nodata=None, pixel_size=None, origin=None,
         projection_wkt=None, target_path=target_kernel_path)

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -82,7 +82,7 @@ def dichotomous_kernel(
     Args:
         target_kernel_path: The path to where the kernel will be written.
             Must have a file extension of ``.tif``.
-        max_distance: The maximum distance of the kernel, in pixels. Kernel
+        max_distance: The distance threshold, in pixels. Kernel
             pixels that are greater than ``max_distance`` from the centerpoint
             of the kernel will have values of ``0.0``.
         apothem: The apothem of the target kernel, in pixels.  If ``None``,

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -17,12 +17,6 @@ LOGGER = logging.getLogger(__name__)
 # TODO: what happens if kernels are not centered on the target pixel?
 # TODO: use type hints for these modules and note it in the changelog.
 
-# ok, so the questions needed when we have a kernel is:
-#   * how big should the kernel be (pixel radius)
-#   * what function should be used to determine pixel values (function of
-#     distance from centerpoint)
-#   * should the kernel be normalized.
-
 
 def kernel_from_numpy_array(numpy_array, target_kernel_path):
     """Create a convolution kernel from a numpy array.
@@ -32,7 +26,8 @@ def kernel_from_numpy_array(numpy_array, target_kernel_path):
         projection_wkt=None, target_path=target_kernel_path)
 
 
-def dichotomous_kernel(target_kernel_path, max_distance, **kwargs):
+def dichotomous_kernel(target_kernel_path, max_distance, pixel_radius=None,
+                       normalize=True):
     """Create a binary kernel indicating presence/absence within a distance.
 
     Given a centerpoint pixel C and an arbitrary pixel P in the target kernel,
@@ -51,40 +46,61 @@ def dichotomous_kernel(target_kernel_path, max_distance, **kwargs):
         ``None``
     """
     create_kernel(
-        target_kernel_path, "dist <= max_dist", max_distance,
-        **kwargs)
+        target_kernel_path=target_kernel_path,
+        function="dist <= max_dist",
+        max_distance=max_distance,
+        pixel_radius=pixel_radius,
+        normalize=normalize
+    )
 
 
 # UNA calls this a density kernel
 # really, this is quite specific to UNA
-def parabolic_decay_kernel(target_kernel_path, max_distance, **kwargs):
+def parabolic_decay_kernel(target_kernel_path, max_distance, pixel_radius=None,
+                           normalize=True):
     """Create an inverted parabola that reaches 0 at ``max_distance``
     """
     create_kernel(
-        target_kernel_path, "0.75 * (1-(dist / max_dist) ** 2)",
-        max_distance, **kwargs)
+        target_kernel_path=target_kernel_path,
+        function="0.75 * (1-(dist / max_dist) ** 2)",
+        max_distance=max_distance,
+        pixel_radius=pixel_radius,
+        normalize=normalize
+    )
 
 
-def exponential_decay_kernel(target_kernel_path, expected_distance,
-                             max_distance, **kwargs):
+def exponential_decay_kernel(target_kernel_path, max_distance,
+                             expected_distance, pixel_radius=None,
+                             normalize=True):
     create_kernel(
-        target_kernel_path, f"exp(-dist / {expected_distance})",
-        max_distance, **kwargs)
+        target_kernel_path=target_kernel_path,
+        function=f"exp(-dist / {expected_distance})",
+        max_distance=max_distance,
+        pixel_radius=pixel_radius,
+        normalize=normalize
+    )
 
 
-def linear_decay_kernel(target_kernel_path, max_distance, **kwargs):
+def linear_decay_kernel(target_kernel_path, max_distance, pixel_radius=None,
+                        normalize=True):
     create_kernel(
-        target_kernel_path, "(max_dist - dist) / max_dist",
-        max_distance, **kwargs)
+        target_kernel_path=target_kernel_path,
+        function="(max_dist - dist) / max_dist",
+        max_distance=max_distance,
+        pixel_radius=pixel_radius,
+        normalize=normalize
+    )
 
 
-def normal_distribution_kernel(target_kernel_path, sigma, n_std_dev=3,
-                               **kwargs):
+def normal_distribution_kernel(target_kernel_path, sigma,
+                               n_std_dev=3, pixel_radius=None, normalize=True):
     create_kernel(
-        target_kernel_path,
+        target_kernel_path=target_kernel_path,
         function=f"(1/(2*pi*{sigma}**2))*exp((-dist**2)/(2*{sigma}**2))",
         max_distance=(sigma * n_std_dev),
-        **kwargs)
+        pixel_radius=pixel_radius,
+        normalize=normalize
+    )
 
 
 def create_kernel(

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -91,6 +91,7 @@ def create_kernel(
         target_kernel_path: str,
         function: Union[str, Callable],
         max_distance: Union[int, float],
+        pixel_radius=None,
         normalize=True):
     """
     Create a kernel raster based on pixel distance from the centerpoint.
@@ -105,12 +106,15 @@ def create_kernel(
         max_distance (float): The maximum distance of kernel values from
             the center point.  Values outside of this distance will be set to
             ``0.0``.
+        pixel_radius=None (float): The radius (in pixels) of the target kernel.
+            If ``None``, the radius will be ``math.ceil(max_distance)``.
         normalize=False (bool): Whether to normalize the resulting kernel.
 
     Returns:
         ``None``
     """
-    pixel_radius = math.ceil(max_distance)
+    if pixel_radius is None:
+        pixel_radius = math.ceil(max_distance)
     kernel_size = pixel_radius * 2 + 1  # allow for a center pixel
     driver = gdal.GetDriverByName('GTiff')
     kernel_dataset = driver.Create(

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -1,5 +1,3 @@
-import dataclasses
-import functools
 import logging
 import math
 from typing import Callable
@@ -8,7 +6,6 @@ from typing import Union
 import numpy
 import pygeoprocessing
 from osgeo import gdal
-from osgeo import osr
 
 FLOAT32_NODATA = float(numpy.finfo(numpy.float32).min)
 LOGGER = logging.getLogger(__name__)
@@ -66,16 +63,6 @@ def parabolic_decay_kernel(target_kernel_path, max_distance, normalize=True):
     create_kernel(
         target_kernel_path, "0.75 * (1-(dist / max_dist) ** 2)",
         max_distance, normalize=normalize)
-
-
-def numexpr_kernel(target_kernel_path, max_distance, expression, extras=None):
-    import numexpr
-    if not extras:
-        extras = {}
-
-    def _numexpr_expression(distance_from_center):
-        # evaluate a numexpr expression provided by the user
-        return numexpr.evaluate(expression)
 
 
 def exponential_decay_kernel(target_kernel_path, max_distance,

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -12,13 +12,6 @@ from osgeo import gdal
 FLOAT32_NODATA = float(numpy.finfo(numpy.float32).min)
 LOGGER = logging.getLogger(__name__)
 
-# note that convolve_2d requires that all pixels are valid
-#    pixels may not be nodata.
-# TODO: are kernels required to be square?
-#     From what I can tell, no, they just need to have same num. dimensions.
-# TODO: what happens if kernels are not centered on the target pixel?
-# TODO: use type hints for these modules and note it in the changelog.
-
 
 def kernel_from_numpy_array(
         numpy_array: ArrayLike, target_kernel_path: Text) -> None:
@@ -198,7 +191,7 @@ def create_kernel(
             be written on disk.  If this file does not have the suffix
             ``.tif``, it will be added to the filepath.
         function (callable): A python callable that takes as input a
-            2D numpy array and returns a 2D numpy array.  The input array will
+            1D numpy array and returns a 1D numpy array.  The input array will
             contain float32 distances to the centerpoint pixel of the kernel.
         max_distance (float): The maximum distance of kernel values from
             the center point.  Values outside of this distance will be set to

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -1,6 +1,7 @@
 import logging
 import math
 from typing import Callable
+from typing import Text
 from typing import Union
 
 import numpy
@@ -69,12 +70,38 @@ def parabolic_decay_kernel(target_kernel_path, max_distance, pixel_radius=None,
     )
 
 
-def exponential_decay_kernel(target_kernel_path, max_distance,
-                             expected_distance, pixel_radius=None,
-                             normalize=True):
+def exponential_decay_kernel(
+        target_kernel_path: Text,
+        max_distance: Union[int, float],
+        expected_distance: Union[int, float],
+        pixel_radius: Union[int, float] = None,
+        normalize: bool = True) -> None:
+    """Create an exponential decay kernel.
+
+    This kernel will reach 1/e at ``expected_distance``, but will continue to
+    have nonzero values out to ``max_distance``.
+
+    Args:
+        target_kernel_path: The path to where the kernel will be written.
+            Must have a file extension of ``.tif``.
+        max_distance: The maximum distance of the kernel, in pixels. Kernel
+            pixels that are greater than ``max_distance`` from the centerpoint
+            of the kernel will have values of ``0.0``.
+        expected_distance: The distance, in pixels, from the centerpoint at
+            which decayed values will equal ``1/e``.
+        pixel_radius: The radius of the target kernel, in pixels.  If ``None``,
+            then ``math.ceil(max_distance)`` will be used.
+        normalize: Whether to normalize the kernel.
+
+    Returns:
+        ``None``
+    """
+    def _exponential_decay(dist):
+        return numpy.exp(-dist / expected_distance)
+
     create_kernel(
         target_kernel_path=target_kernel_path,
-        function=f"exp(-dist / {expected_distance})",
+        function=_exponential_decay,
         max_distance=max_distance,
         pixel_radius=pixel_radius,
         normalize=normalize

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -20,6 +20,12 @@ LOGGER = logging.getLogger(__name__)
 # TODO: what happens if kernels are not centered on the target pixel?
 # TODO: use type hints for these modules and note it in the changelog.
 
+# ok, so the questions needed when we have a kernel is:
+#   * how big should the kernel be (pixel radius)
+#   * what function should be used to determine pixel values (function of
+#     distance from centerpoint)
+#   * should the kernel be normalized.
+
 
 def kernel_from_numpy_array(numpy_array, target_kernel_path):
     """Create a convolution kernel from a numpy array.
@@ -51,7 +57,7 @@ def dichotomous_kernel(target_kernel_path, max_distance):
         return numpy.array(
             distance_from_center <= max_distance, dtype=numpy.float32)
 
-    _create_distance_based_kernel(
+    create_kernel(
         target_kernel_path, _dichotomy, max_distance, normalize=False)
 
 
@@ -70,7 +76,7 @@ def parabolic_decay_kernel(target_kernel_path, max_distance):
                 pixels_in_radius] / max_distance) ** 2))
         return density
 
-    _create_distance_based_kernel(
+    create_kernel(
         target_kernel_path, _density, max_distance, normalize=False)
 
 
@@ -92,7 +98,7 @@ def exponential_decay_kernel(target_kernel_path, max_distance,
             numpy.exp(-(distance_from_center*distance_factor) / max_distance))
         return kernel
 
-    _create_distance_based_kernel(
+    create_kernel(
         target_kernel_path, _exp_decay, max_distance, normalize=True)
 
 
@@ -102,7 +108,7 @@ def linear_decay_kernel(target_kernel_path, max_distance):
             distance_from_center > max_distance, 0.0,
             (max_distance - distance_from_center) / max_distance)
 
-    _create_distance_based_kernel(
+    create_kernel(
         target_kernel_path, _linear_decay, max_distance, normalize=True)
 
 
@@ -116,11 +122,11 @@ def gaussian_decay_kernel(target_kernel_path, sigma, n_std_dev):
              numpy.exp(-distance_from_center**2 / (2 * sigma ** 2))))
         return kernel
 
-    _create_distance_based_kernel(
+    create_kernel(
         target_kernel_path, _gaussian_decay, max_distance, normalize=True)
 
 
-def _create_distance_based_kernel(
+def create_kernel(
         target_kernel_path: str,
         function: Union[str, Callable],
         max_distance: Union[int, float],

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -79,40 +79,6 @@ def dichotomous_kernel(
     )
 
 
-def parabolic_decay_kernel(
-        target_kernel_path: Text,
-        max_distance: Union[int, float],
-        pixel_radius: Union[int, float] = None,
-        normalize: bool = True) -> None:
-    """Create a kernel matching an inverted parabola.
-
-    This parabola reaches 0 at ``max_distance``.
-
-    Args:
-        target_kernel_path: The path to where the kernel will be written.
-            Must have a file extension of ``.tif``.
-        max_distance: The maximum distance of the kernel, in pixels. Kernel
-            pixels that are greater than ``max_distance`` from the centerpoint
-            of the kernel will have values of ``0.0``.
-        pixel_radius: The radius of the target kernel, in pixels.  If ``None``,
-            then ``math.ceil(max_distance)`` will be used.
-        normalize: Whether to normalize the kernel.
-
-    Returns:
-        ``None``
-    """
-    def _parabolic_decay(dist):
-        return 0.75 * (1 - dist / max_distance) ** 2
-
-    create_kernel(
-        target_kernel_path=target_kernel_path,
-        function=_parabolic_decay,
-        max_distance=max_distance,
-        pixel_radius=pixel_radius,
-        normalize=normalize
-    )
-
-
 def exponential_decay_kernel(
         target_kernel_path: Text,
         max_distance: Union[int, float],

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -55,15 +55,34 @@ def dichotomous_kernel(target_kernel_path, max_distance, pixel_radius=None,
     )
 
 
-# UNA calls this a density kernel
-# really, this is quite specific to UNA
-def parabolic_decay_kernel(target_kernel_path, max_distance, pixel_radius=None,
-                           normalize=True):
-    """Create an inverted parabola that reaches 0 at ``max_distance``
+def parabolic_decay_kernel(
+        target_kernel_path: Text,
+        max_distance: Union[int, float],
+        pixel_radius: Union[int, float] = None,
+        normalize: bool = True) -> None:
+    """Create a kernel matching an inverted parabola.
+
+    This parabola reaches 0 at ``max_distance``.
+
+    Args:
+        target_kernel_path: The path to where the kernel will be written.
+            Must have a file extension of ``.tif``.
+        max_distance: The maximum distance of the kernel, in pixels. Kernel
+            pixels that are greater than ``max_distance`` from the centerpoint
+            of the kernel will have values of ``0.0``.
+        pixel_radius: The radius of the target kernel, in pixels.  If ``None``,
+            then ``math.ceil(max_distance)`` will be used.
+        normalize: Whether to normalize the kernel.
+
+    Returns:
+        ``None``
     """
+    def _parabolic_decay(dist):
+        return 0.75 * (1 - dist / max_distance) ** 2
+
     create_kernel(
         target_kernel_path=target_kernel_path,
-        function="0.75 * (1-(dist / max_dist) ** 2)",
+        function=_parabolic_decay,
         max_distance=max_distance,
         pixel_radius=pixel_radius,
         normalize=normalize
@@ -128,7 +147,6 @@ def linear_decay_kernel(
     Returns:
         ``None``
     """
-
     def _linear_decay(dist):
         return (max_distance - dist) / max_distance
 

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -246,7 +246,7 @@ def create_distance_decay_kernel(
             the center point.  Values outside of this distance will be set to
             ``0.0``.
         apothem=None (float): The apothem (in pixels) of the target kernel.
-            If ``None``, the apothem will be ``math.ceil(max_distance)``.
+            If ``None``, the apothem will be ``math.floor(max_distance)``.
         normalize=False (bool): Whether to normalize the resulting kernel.
 
     Returns:
@@ -254,7 +254,10 @@ def create_distance_decay_kernel(
     """
     if apothem is None:
         apothem = max_distance
-    apothem = math.ceil(apothem)
+    if max_distance > apothem:
+        raise AssertionError(
+            "max_distance must be less than or equal to the apothem.")
+    apothem = math.floor(apothem)
     kernel_size = apothem * 2 + 1  # allow for a center pixel
     assert kernel_size % 2 == 1
     driver = gdal.GetDriverByName('GTiff')

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -8,6 +8,17 @@ from osgeo import osr
 
 FLOAT32_NODATA = numpy.finfo(numpy.float32).min
 LOGGER = logging.getLogger(__name__)
+_DEFAULT_SRS = osr.SpatialReference()
+_DEFAULT_SRS.SetWellKnownGeogCS('WGS84')
+_DEFAULT_GEOTRANSFORM = [0, 1, 0, 0, 0, -1]
+
+
+def kernel_from_numpy_array(numpy_array, target_kernel_path):
+    pixel_size = (_DEFAULT_GEOTRANSFORM[1], _DEFAULT_GEOTRANSFORM[5])
+    origin = (_DEFAULT_GEOTRANSFORM[0], _DEFAULT_GEOTRANSFORM[3])
+    pygeoprocessing.numpy_array_to_raster(
+        numpy_array, None, pixel_size, origin,
+        _DEFAULT_SRS.ExportToWkt(), target_kernel_path)
 
 
 def dichotomous_kernel(target_kernel_path, max_distance):
@@ -99,10 +110,8 @@ def _create_distance_based_kernel(
 
     # Make some kind of geotransform, it doesn't matter what but
     # will make GIS libraries behave better if it's all defined
-    kernel_dataset.SetGeoTransform([0, 1, 0, 0, 0, -1])
-    srs = osr.SpatialReference()
-    srs.SetWellKnownGeogCS('WGS84')
-    kernel_dataset.SetProjection(srs.ExportToWkt())
+    kernel_dataset.SetGeoTransform(_DEFAULT_GEOTRANSFORM)
+    kernel_dataset.SetProjection(_DEFAULT_SRS.ExportToWkt())
 
     kernel_band = kernel_dataset.GetRasterBand(1)
     kernel_nodata = FLOAT32_NODATA

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -155,7 +155,6 @@ def normal_distribution_kernel(
         target_kernel_path: Text,
         sigma: Union[int, float],
         n_std_dev: Union[int, float] = 3,
-        pixel_radius: Union[int, float] = None,
         normalize: bool = True):
     """Create an decay kernel following a normal distribution.
 
@@ -171,8 +170,6 @@ def normal_distribution_kernel(
         n_std_dev: The number of standard deviations to include in the kernel.
             The kernel will have values of 0 when at a distance of
             ``(sigma * n_std_dev)`` away from the centerpoint.
-        pixel_radius: The radius of the target kernel, in pixels.  If ``None``,
-            then ``math.ceil(sigma * n_std_dev)`` will be used.
         normalize: Whether to normalize the kernel.
 
     Returns:
@@ -186,7 +183,6 @@ def normal_distribution_kernel(
         target_kernel_path=target_kernel_path,
         distance_decay_function=_normal_decay,
         max_distance=(sigma * n_std_dev),
-        pixel_radius=pixel_radius,
         normalize=normalize
     )
 

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -119,11 +119,35 @@ def linear_decay_kernel(target_kernel_path, max_distance, pixel_radius=None,
     )
 
 
-def normal_distribution_kernel(target_kernel_path, sigma,
-                               n_std_dev=3, pixel_radius=None, normalize=True):
+def normal_distribution_kernel(
+        target_kernel_path: Text,
+        sigma: Union[int, float],
+        n_std_dev: Union[int, float] = 3,
+        pixel_radius: Union[int, float] = None,
+        normalize: bool = True):
+    """Create an decay kernel following a normal distribution.
+
+    Args:
+        target_kernel_path: The path to where the kernel will be written.
+            Must have a file extension of ``.tif``.
+        sigma: The width (in pixels) of a standard deviation.
+        n_std_dev: The number of standard deviations to include in the kernel.
+            The kernel will have values of 0 when at a distance of
+            ``(sigma * n_std_dev)`` away from the centerpoint.
+        pixel_radius: The radius of the target kernel, in pixels.  If ``None``,
+            then ``math.ceil(sigma * n_std_dev)`` will be used.
+        normalize: Whether to normalize the kernel.
+
+    Returns:
+        ``None``
+    """
+    def _normal_decay(dist):
+        return (1 / (2 * numpy.pi * sigma ** 2)) * numpy.exp(
+            (-dist ** 2) / (2 * sigma ** 2))
+
     create_kernel(
         target_kernel_path=target_kernel_path,
-        function=f"(1/(2*pi*{sigma}**2))*exp((-dist**2)/(2*{sigma}**2))",
+        function=_normal_decay,
         max_distance=(sigma * n_std_dev),
         pixel_radius=pixel_radius,
         normalize=normalize

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -177,7 +177,8 @@ def _create_distance_based_kernel(
         numpy_namespace = {name: getattr(numpy, name) for name in dir(numpy)}
 
         def function(d):
-            return eval(code, locals={'d': d}, globals=numpy_namespace)
+            return eval(code, locals={'dist': d, 'max_dist': max_distance},
+                        globals=numpy_namespace)
 
     for block_data in pygeoprocessing.iterblocks(
             (target_kernel_path, 1), offset_only=True):
@@ -194,8 +195,12 @@ def _create_distance_based_kernel(
             *numpy.mgrid[
                 array_ymin:array_ymax,
                 array_xmin:array_xmax])
+
         kernel = function(pixel_dist_from_center)
-        running_sum += kernel.sum()
+
+        if normalize:
+            running_sum += kernel.sum()
+
         kernel_band.WriteArray(
             kernel,
             yoff=block_data['yoff'],

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -86,7 +86,7 @@ def dichotomous_kernel(
             pixels that are greater than ``max_distance`` from the centerpoint
             of the kernel will have values of ``0.0``.
         apothem: The apothem of the target kernel, in pixels.  If ``None``,
-            then ``math.ceil(max_distance)`` will be used.
+            then ``math.floor(max_distance)`` will be used.
         normalize: Whether to normalize the kernel.
 
     Returns:
@@ -128,7 +128,7 @@ def exponential_decay_kernel(
         expected_distance: The distance, in pixels, from the centerpoint at
             which decayed values will equal ``1/e``.
         apothem: The apothem of the target kernel, in pixels.  If ``None``,
-            then ``math.ceil(max_distance)`` will be used.
+            then ``math.floor(max_distance)`` will be used.
         normalize: Whether to normalize the kernel.
 
     Returns:
@@ -165,7 +165,7 @@ def linear_decay_kernel(
             pixels that are greater than ``max_distance`` from the centerpoint
             of the kernel will have values of ``0.0``.
         apothem: The apothem of the target kernel, in pixels.  If ``None``,
-            then ``math.ceil(max_distance)`` will be used.
+            then ``math.floor(max_distance)`` will be used.
         normalize: Whether to normalize the kernel.
 
     Returns:

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -43,8 +43,11 @@ def kernel_from_numpy_array(
         projection_wkt=None, target_path=target_kernel_path)
 
 
-def dichotomous_kernel(target_kernel_path, max_distance, pixel_radius=None,
-                       normalize=True):
+def dichotomous_kernel(
+        target_kernel_path: Text,
+        max_distance: Union[int, float],
+        pixel_radius: Union[int, float] = None,
+        normalize: bool = True) -> None:
     """Create a binary kernel indicating presence/absence within a distance.
 
     Given a centerpoint pixel C and an arbitrary pixel P in the target kernel,
@@ -52,19 +55,24 @@ def dichotomous_kernel(target_kernel_path, max_distance, pixel_radius=None,
     will be 0.  The value of P will be 1 otherwise.
 
     Args:
-        target_kernel_path (string): Where the target kernel file should be
-            stored.
-        max_distance (float): The maximum distance within which pixels should
-            indicate presence (1) in the output kernel.  Pixels that are more
-            than this distance (in units of pixels) from the center pixel will
-            indicate absence (0) in the output kernel.
+        target_kernel_path: The path to where the kernel will be written.
+            Must have a file extension of ``.tif``.
+        max_distance: The maximum distance of the kernel, in pixels. Kernel
+            pixels that are greater than ``max_distance`` from the centerpoint
+            of the kernel will have values of ``0.0``.
+        pixel_radius: The radius of the target kernel, in pixels.  If ``None``,
+            then ``math.ceil(max_distance)`` will be used.
+        normalize: Whether to normalize the kernel.
 
     Returns:
         ``None``
     """
+    def _dichotomous(dist):
+        return dist <= max_distance
+
     create_kernel(
         target_kernel_path=target_kernel_path,
-        function="dist <= max_dist",
+        function=_dichotomous,
         max_distance=max_distance,
         pixel_radius=pixel_radius,
         normalize=normalize

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -108,8 +108,30 @@ def exponential_decay_kernel(
     )
 
 
-def linear_decay_kernel(target_kernel_path, max_distance, pixel_radius=None,
-                        normalize=True):
+def linear_decay_kernel(
+        target_kernel_path: Text,
+        max_distance: Union[int, float],
+        pixel_radius: Union[int, float] = None,
+        normalize: bool = True) -> None:
+    """Create a linear decay kernel.
+
+    Args:
+        target_kernel_path: The path to where the kernel will be written.
+            Must have a file extension of ``.tif``.
+        max_distance: The maximum distance of the kernel, in pixels. Kernel
+            pixels that are greater than ``max_distance`` from the centerpoint
+            of the kernel will have values of ``0.0``.
+        pixel_radius: The radius of the target kernel, in pixels.  If ``None``,
+            then ``math.ceil(max_distance)`` will be used.
+        normalize: Whether to normalize the kernel.
+
+    Returns:
+        ``None``
+    """
+
+    def _linear_decay(dist):
+        return (max_distance - dist) / max_distance
+
     create_kernel(
         target_kernel_path=target_kernel_path,
         function="(max_dist - dist) / max_dist",

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -63,7 +63,7 @@ def dichotomous_kernel(
     def _dichotomous(dist):
         return dist <= max_distance
 
-    create_kernel(
+    create_distance_decay_kernel(
         target_kernel_path=target_kernel_path,
         function=_dichotomous,
         max_distance=max_distance,
@@ -101,7 +101,7 @@ def exponential_decay_kernel(
     def _exponential_decay(dist):
         return numpy.exp(-dist / expected_distance)
 
-    create_kernel(
+    create_distance_decay_kernel(
         target_kernel_path=target_kernel_path,
         function=_exponential_decay,
         max_distance=max_distance,
@@ -133,7 +133,7 @@ def linear_decay_kernel(
     def _linear_decay(dist):
         return (max_distance - dist) / max_distance
 
-    create_kernel(
+    create_distance_decay_kernel(
         target_kernel_path=target_kernel_path,
         function="(max_dist - dist) / max_dist",
         max_distance=max_distance,
@@ -168,7 +168,7 @@ def normal_distribution_kernel(
         return (1 / (2 * numpy.pi * sigma ** 2)) * numpy.exp(
             (-dist ** 2) / (2 * sigma ** 2))
 
-    create_kernel(
+    create_distance_decay_kernel(
         target_kernel_path=target_kernel_path,
         function=_normal_decay,
         max_distance=(sigma * n_std_dev),
@@ -177,7 +177,7 @@ def normal_distribution_kernel(
     )
 
 
-def create_kernel(
+def create_distance_decay_kernel(
         target_kernel_path: str,
         function: Union[str, Callable],
         max_distance: Union[int, float],

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -173,12 +173,15 @@ def _create_distance_based_kernel(
     # python expression appropriate for evaling.
     if isinstance(function, str):
         # Avoid recompiling on each iteration.
-        code = compile(function, '<string>', 'eval'),
+        code = compile(function, '<string>', 'eval')
         numpy_namespace = {name: getattr(numpy, name) for name in dir(numpy)}
 
         def function(d):
-            return eval(code, locals={'dist': d, 'max_dist': max_distance},
-                        globals=numpy_namespace)
+            result = eval(
+                code,
+                numpy_namespace,  # globals
+                {'dist': d, 'max_dist': max_distance})  # locals
+            return result
 
     for block_data in pygeoprocessing.iterblocks(
             (target_kernel_path, 1), offset_only=True):

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -82,7 +82,7 @@ def normal_distribution_kernel(target_kernel_path, sigma, n_std_dev=3,
                                **kwargs):
     create_kernel(
         target_kernel_path,
-        expression=f"(1/(2*pi*{sigma}**2))*exp((-dist**2)/(2*{sigma}**2))",
+        function=f"(1/(2*pi*{sigma}**2))*exp((-dist**2)/(2*{sigma}**2))",
         max_distance=(sigma * n_std_dev),
         **kwargs)
 
@@ -114,8 +114,10 @@ def create_kernel(
         ``None``
     """
     if pixel_radius is None:
-        pixel_radius = math.ceil(max_distance)
+        pixel_radius = max_distance
+    pixel_radius = math.ceil(pixel_radius)
     kernel_size = pixel_radius * 2 + 1  # allow for a center pixel
+    assert kernel_size % 2 == 1
     driver = gdal.GetDriverByName('GTiff')
     kernel_dataset = driver.Create(
         target_kernel_path.encode('utf-8'), kernel_size, kernel_size, 1,

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -32,7 +32,7 @@ def kernel_from_numpy_array(numpy_array, target_kernel_path):
         projection_wkt=None, target_path=target_kernel_path)
 
 
-def dichotomous_kernel(target_kernel_path, max_distance, normalize):
+def dichotomous_kernel(target_kernel_path, max_distance, **kwargs):
     """Create a binary kernel indicating presence/absence within a distance.
 
     Given a centerpoint pixel C and an arbitrary pixel P in the target kernel,
@@ -52,39 +52,39 @@ def dichotomous_kernel(target_kernel_path, max_distance, normalize):
     """
     create_kernel(
         target_kernel_path, "dist <= max_dist", max_distance,
-        normalize=normalize)
+        **kwargs)
 
 
 # UNA calls this a density kernel
 # really, this is quite specific to UNA
-def parabolic_decay_kernel(target_kernel_path, max_distance, normalize=True):
+def parabolic_decay_kernel(target_kernel_path, max_distance, **kwargs):
     """Create an inverted parabola that reaches 0 at ``max_distance``
     """
     create_kernel(
         target_kernel_path, "0.75 * (1-(dist / max_dist) ** 2)",
-        max_distance, normalize=normalize)
+        max_distance, **kwargs)
 
 
 def exponential_decay_kernel(target_kernel_path, max_distance,
-                             normalize=True):
+                             **kwargs):
     create_kernel(
         target_kernel_path, "exp(-dist / max_dist)",
-        max_distance, normalize=normalize)
+        max_distance, **kwargs)
 
 
-def linear_decay_kernel(target_kernel_path, max_distance, normalize=True):
+def linear_decay_kernel(target_kernel_path, max_distance, **kwargs):
     create_kernel(
         target_kernel_path, "(max_dist - dist) / max_dist",
-        max_distance, normalize=normalize)
+        max_distance, **kwargs)
 
 
 def normal_distribution_kernel(target_kernel_path, sigma, n_std_dev=3,
-                               normalize=True):
+                               **kwargs):
     create_kernel(
         target_kernel_path,
         expression=f"(1/(2*pi*{sigma}**2))*exp((-dist**2)/(2*{sigma}**2))",
         max_distance=(sigma * n_std_dev),
-        normalize=normalize)
+        **kwargs)
 
 
 def create_kernel(

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -91,16 +91,13 @@ def linear_decay_kernel(target_kernel_path, max_distance, normalize=True):
         max_distance, normalize=normalize)
 
 
-def gaussian_decay_kernel(target_kernel_path, sigma, n_std_dev=3,
-                          normalize=True):
-    max_distance = sigma * n_std_dev
-
-    def _gaussian_decay(dist):
-        return (1 / (2 * numpy.pi * sigma ** 2) * numpy.exp(
-            -dist ** 2 / (2 * sigma ** 2)))
-
+def normal_distribution_kernel(target_kernel_path, sigma, n_std_dev=3,
+                               normalize=True):
     create_kernel(
-        target_kernel_path, _gaussian_decay, max_distance, normalize=normalize)
+        target_kernel_path,
+        expression=f"(1/(2*pi*{sigma}**2))*exp((-dist**2)/(2*{sigma}**2))",
+        max_distance=(sigma * n_std_dev),
+        normalize=normalize)
 
 
 def create_kernel(

--- a/src/pygeoprocessing/kernels.py
+++ b/src/pygeoprocessing/kernels.py
@@ -39,7 +39,7 @@ def kernel_from_numpy_array(
 def dichotomous_kernel(
         target_kernel_path: Text,
         max_distance: Union[int, float],
-        pixel_radius: Union[int, float] = None,
+        apothem: Union[int, float] = None,
         normalize: bool = True) -> None:
     """Create a binary kernel indicating presence/absence within a distance.
 
@@ -53,7 +53,7 @@ def dichotomous_kernel(
         max_distance: The maximum distance of the kernel, in pixels. Kernel
             pixels that are greater than ``max_distance`` from the centerpoint
             of the kernel will have values of ``0.0``.
-        pixel_radius: The radius of the target kernel, in pixels.  If ``None``,
+        apothem: The apothem of the target kernel, in pixels.  If ``None``,
             then ``math.ceil(max_distance)`` will be used.
         normalize: Whether to normalize the kernel.
 
@@ -67,7 +67,7 @@ def dichotomous_kernel(
         target_kernel_path=target_kernel_path,
         distance_decay_function=_dichotomous,
         max_distance=max_distance,
-        pixel_radius=pixel_radius,
+        apothem=apothem,
         normalize=normalize
     )
 
@@ -76,7 +76,7 @@ def exponential_decay_kernel(
         target_kernel_path: Text,
         max_distance: Union[int, float],
         expected_distance: Union[int, float],
-        pixel_radius: Union[int, float] = None,
+        apothem: Union[int, float] = None,
         normalize: bool = True) -> None:
     """Create an exponential decay kernel.
 
@@ -95,7 +95,7 @@ def exponential_decay_kernel(
             of the kernel will have values of ``0.0``.
         expected_distance: The distance, in pixels, from the centerpoint at
             which decayed values will equal ``1/e``.
-        pixel_radius: The radius of the target kernel, in pixels.  If ``None``,
+        apothem: The apothem of the target kernel, in pixels.  If ``None``,
             then ``math.ceil(max_distance)`` will be used.
         normalize: Whether to normalize the kernel.
 
@@ -109,7 +109,7 @@ def exponential_decay_kernel(
         target_kernel_path=target_kernel_path,
         distance_decay_function=_exponential_decay,
         max_distance=max_distance,
-        pixel_radius=pixel_radius,
+        apothem=apothem,
         normalize=normalize
     )
 
@@ -117,7 +117,7 @@ def exponential_decay_kernel(
 def linear_decay_kernel(
         target_kernel_path: Text,
         max_distance: Union[int, float],
-        pixel_radius: Union[int, float] = None,
+        apothem: Union[int, float] = None,
         normalize: bool = True) -> None:
     """Create a linear decay kernel.
 
@@ -132,7 +132,7 @@ def linear_decay_kernel(
         max_distance: The maximum distance of the kernel, in pixels. Kernel
             pixels that are greater than ``max_distance`` from the centerpoint
             of the kernel will have values of ``0.0``.
-        pixel_radius: The radius of the target kernel, in pixels.  If ``None``,
+        apothem: The apothem of the target kernel, in pixels.  If ``None``,
             then ``math.ceil(max_distance)`` will be used.
         normalize: Whether to normalize the kernel.
 
@@ -146,7 +146,7 @@ def linear_decay_kernel(
         target_kernel_path=target_kernel_path,
         distance_decay_function=_linear_decay,
         max_distance=max_distance,
-        pixel_radius=pixel_radius,
+        apothem=apothem,
         normalize=normalize
     )
 
@@ -191,7 +191,7 @@ def create_distance_decay_kernel(
         target_kernel_path: str,
         distance_decay_function: Union[str, Callable],
         max_distance: Union[int, float],
-        pixel_radius=None,
+        apothem=None,
         normalize=True):
     """
     Create a kernel raster based on pixel distance from the centerpoint.
@@ -207,17 +207,17 @@ def create_distance_decay_kernel(
         max_distance (float): The maximum distance of kernel values from
             the center point.  Values outside of this distance will be set to
             ``0.0``.
-        pixel_radius=None (float): The radius (in pixels) of the target kernel.
-            If ``None``, the radius will be ``math.ceil(max_distance)``.
+        apothem=None (float): The apothem (in pixels) of the target kernel.
+            If ``None``, the apothem will be ``math.ceil(max_distance)``.
         normalize=False (bool): Whether to normalize the resulting kernel.
 
     Returns:
         ``None``
     """
-    if pixel_radius is None:
-        pixel_radius = max_distance
-    pixel_radius = math.ceil(pixel_radius)
-    kernel_size = pixel_radius * 2 + 1  # allow for a center pixel
+    if apothem is None:
+        apothem = max_distance
+    apothem = math.ceil(apothem)
+    kernel_size = apothem * 2 + 1  # allow for a center pixel
     assert kernel_size % 2 == 1
     driver = gdal.GetDriverByName('GTiff')
     kernel_dataset = driver.Create(
@@ -259,14 +259,14 @@ def create_distance_decay_kernel(
 
     for block_data in pygeoprocessing.iterblocks(
             (target_kernel_path, 1), offset_only=True):
-        array_xmin = block_data['xoff'] - pixel_radius
+        array_xmin = block_data['xoff'] - apothem
         array_xmax = min(
             array_xmin + block_data['win_xsize'],
-            band_x_size - pixel_radius)
-        array_ymin = block_data['yoff'] - pixel_radius
+            band_x_size - apothem)
+        array_ymin = block_data['yoff'] - apothem
         array_ymax = min(
             array_ymin + block_data['win_ysize'],
-            band_y_size - pixel_radius)
+            band_y_size - apothem)
 
         pixel_dist_from_center = numpy.hypot(
             *numpy.mgrid[

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -157,3 +157,17 @@ class KernelTests(unittest.TestCase):
             numpy.testing.assert_allclose(numpy.unique(array[71:][:]), 0)
             numpy.testing.assert_allclose(numpy.unique(array[:][:10]), 0)
             numpy.testing.assert_allclose(numpy.unique(array[:][71:]), 0)
+
+    def test_max_distance_vs_apothem(self):
+        """Kernels: test the kernel distance vs the apothem."""
+        import pygeoprocessing.kernels
+
+        my_kernel = "dist <= max_dist"
+        with self.assertRaises(AssertionError) as cm:
+            pygeoprocessing.kernels.create_distance_decay_kernel(
+                self.filepath, my_kernel, max_distance=40, apothem=30,
+                normalize=True)
+
+        self.assertIn(
+            str(cm.exception).lower(),
+            'max_distance must be less than or equal to the apothem.')

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -53,7 +53,19 @@ class KernelTests(unittest.TestCase):
                       str(cm.exception))
 
     def test_dichotomy(self):
-        from pygeoprocessing import kernels
+        """Kernels: test dichotomous kernel."""
+        import pygeoprocessing.kernels
 
-        kernels.dichotomous_kernel(
-            self.filepath, max_distance=30, normalize=True)
+        max_dist = 30
+        n_nonzero_pixels = 2821
+        for normalize, expected_sum in [(True, 1), (False, n_nonzero_pixels)]:
+            pygeoprocessing.kernels.dichotomous_kernel(
+                self.filepath, max_distance=max_dist, normalize=normalize)
+
+            kernel_array = pygeoprocessing.raster_to_numpy_array(
+                self.filepath)
+
+            self.assertEqual(kernel_array.shape, (max_dist*2+1, max_dist*2+1))
+            numpy.testing.assert_allclose(kernel_array.sum(), expected_sum)
+            self.assertEqual(numpy.count_nonzero(kernel_array),
+                             n_nonzero_pixels)

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -146,7 +146,7 @@ class KernelTests(unittest.TestCase):
         for function in (_my_weird_kernel, my_string_kernel):
             pygeoprocessing.kernels.create_distance_decay_kernel(
                 self.filepath, _my_weird_kernel, max_distance=30,
-                pixel_radius=40, normalize=False)
+                apothem=40, normalize=False)
 
             array = pygeoprocessing.raster_to_numpy_array(self.filepath)
             self.assertEqual(array.shape, (81, 81))

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1,0 +1,59 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+import numpy
+import numpy.testing
+from osgeo import gdal
+
+
+class KernelTests(unittest.TestCase):
+    def setUp(self):
+        self.workspace = tempfile.mkdtemp()
+        self.filepath = os.path.join(self.workspace, 'kernel.tif')
+
+    def tearDown(self):
+        shutil.rmtree(self.workspace)
+
+    def test_kernel_from_array(self):
+        """Kernels: test kernel creation from a numpy array."""
+        import pygeoprocessing
+        import pygeoprocessing.kernels
+
+        # let's use a sharpening mask, just for fun.
+        # https://en.wikipedia.org/wiki/Kernel_(image_processing)
+        kernel = numpy.array([
+            [0, -1, 0],
+            [-1, 5, -1],
+            [0, -1, 0]], dtype=numpy.int32)
+
+        pygeoprocessing.kernels.kernel_from_numpy_array(
+            kernel, self.filepath)
+
+        # This both verifies that we can read the kernel with GDAL and that
+        # it's the datatype we expect.
+        raster_info = pygeoprocessing.get_raster_info(self.filepath)
+        self.assertEqual(raster_info['datatype'], gdal.GDT_Int32)
+
+        numpy.testing.assert_equal(
+            pygeoprocessing.raster_to_numpy_array(self.filepath),
+            kernel)
+
+    def test_kernel_invalid_dimensions(self):
+        """Kernels: test error with invalid dimensions."""
+        import pygeoprocessing.kernels
+
+        kernel = numpy.array([1, 2, 3])
+        with self.assertRaises(ValueError) as cm:
+            pygeoprocessing.kernels.kernel_from_numpy_array(
+                kernel, self.filepath)
+
+        self.assertIn("array must have exactly 2 dimensions, not 1",
+                      str(cm.exception))
+
+    def test_dichotomy(self):
+        from pygeoprocessing import kernels
+
+        kernels.dichotomous_kernel(
+            self.filepath, max_distance=30, normalize=True)

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -146,28 +146,8 @@ class KernelTests(unittest.TestCase):
         for function in (_my_weird_kernel, my_string_kernel):
             pygeoprocessing.kernels.create_distance_decay_kernel(
                 self.filepath, _my_weird_kernel, max_distance=30,
-                apothem=40, normalize=False)
+                normalize=False)
 
             array = pygeoprocessing.raster_to_numpy_array(self.filepath)
-            self.assertEqual(array.shape, (81, 81))
+            self.assertEqual(array.shape, (61, 61))
             self.assertEqual(set(numpy.unique(array)), {-1, 0, 1})
-
-            # confirm the 10-pixel boundaries are all 0
-            numpy.testing.assert_allclose(numpy.unique(array[:10][:]), 0)
-            numpy.testing.assert_allclose(numpy.unique(array[71:][:]), 0)
-            numpy.testing.assert_allclose(numpy.unique(array[:][:10]), 0)
-            numpy.testing.assert_allclose(numpy.unique(array[:][71:]), 0)
-
-    def test_max_distance_vs_apothem(self):
-        """Kernels: test the kernel distance vs the apothem."""
-        import pygeoprocessing.kernels
-
-        my_kernel = "dist <= max_dist"
-        with self.assertRaises(AssertionError) as cm:
-            pygeoprocessing.kernels.create_distance_decay_kernel(
-                self.filepath, my_kernel, max_distance=40, apothem=30,
-                normalize=True)
-
-        self.assertIn(
-            str(cm.exception).lower(),
-            'max_distance must be less than or equal to the apothem.')

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -69,3 +69,23 @@ class KernelTests(unittest.TestCase):
             numpy.testing.assert_allclose(kernel_array.sum(), expected_sum)
             self.assertEqual(numpy.count_nonzero(kernel_array),
                              n_nonzero_pixels)
+
+    def test_exponential_decay(self):
+        """Kernels: test exponential decay."""
+        import pygeoprocessing.kernels
+
+        max_dist = 30
+        expected_distance = 15
+        n_nonzero_pixels = 2821
+        for normalize, expected_sum in [(True, 1), (False, 838.87195)]:
+            pygeoprocessing.kernels.exponential_decay_kernel(
+                self.filepath, max_distance=max_dist,
+                expected_distance=expected_distance, normalize=normalize)
+
+            kernel_array = pygeoprocessing.raster_to_numpy_array(
+                self.filepath)
+
+            self.assertEqual(kernel_array.shape, (max_dist*2+1, max_dist*2+1))
+            numpy.testing.assert_allclose(kernel_array.sum(), expected_sum)
+            self.assertEqual(numpy.count_nonzero(kernel_array),
+                             n_nonzero_pixels)

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -130,7 +130,7 @@ class KernelTests(unittest.TestCase):
             self.assertEqual(numpy.count_nonzero(kernel_array),
                              n_nonzero_pixels)
 
-    def test_create_kernel_callable(self):
+    def test_create_distance_decay_kernel_callable(self):
         """Kernels: test kernel creation from function."""
         import pygeoprocessing.kernels
 
@@ -144,7 +144,7 @@ class KernelTests(unittest.TestCase):
         my_string_kernel = "((floor(dist) % 2) * 2) - 1"
 
         for function in (_my_weird_kernel, my_string_kernel):
-            pygeoprocessing.kernels.create_kernel(
+            pygeoprocessing.kernels.create_distance_decay_kernel(
                 self.filepath, _my_weird_kernel, max_distance=30,
                 pixel_radius=40, normalize=False)
 

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -108,3 +108,24 @@ class KernelTests(unittest.TestCase):
             numpy.testing.assert_allclose(kernel_array.sum(), expected_sum)
             self.assertEqual(numpy.count_nonzero(kernel_array),
                              n_nonzero_pixels)
+
+    def test_normal_distribution(self):
+        """Kernels: test normal distribution."""
+        import pygeoprocessing.kernels
+
+        sigma = 3
+        n_std_dev = 10
+        n_nonzero_pixels = 2821
+        for normalize, expected_sum in [(True, 1), (False, 0.98877025)]:
+            pygeoprocessing.kernels.normal_distribution_kernel(
+                self.filepath, sigma=10, n_std_dev=3,
+                normalize=normalize)
+
+            kernel_array = pygeoprocessing.raster_to_numpy_array(
+                self.filepath)
+
+            max_dist = sigma * n_std_dev
+            self.assertEqual(kernel_array.shape, (max_dist*2+1, max_dist*2+1))
+            numpy.testing.assert_allclose(kernel_array.sum(), expected_sum)
+            self.assertEqual(numpy.count_nonzero(kernel_array),
+                             n_nonzero_pixels)

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -89,3 +89,22 @@ class KernelTests(unittest.TestCase):
             numpy.testing.assert_allclose(kernel_array.sum(), expected_sum)
             self.assertEqual(numpy.count_nonzero(kernel_array),
                              n_nonzero_pixels)
+
+    def test_linear_decay(self):
+        """Kernels: test linear decay."""
+        import pygeoprocessing.kernels
+
+        max_dist = 30
+        n_nonzero_pixels = 2809
+        for normalize, expected_sum in [(True, 1), (False, 942.44055)]:
+            pygeoprocessing.kernels.linear_decay_kernel(
+                self.filepath, max_distance=max_dist,
+                normalize=normalize)
+
+            kernel_array = pygeoprocessing.raster_to_numpy_array(
+                self.filepath)
+
+            self.assertEqual(kernel_array.shape, (max_dist*2+1, max_dist*2+1))
+            numpy.testing.assert_allclose(kernel_array.sum(), expected_sum)
+            self.assertEqual(numpy.count_nonzero(kernel_array),
+                             n_nonzero_pixels)


### PR DESCRIPTION
This PR implements a library of convolution kernels, taken from InVEST where 2 or more models use the kernel.  Some kernels, such as the power and inverted parabolic functions in Urban Nature Access, are not included here as a result.

The major changes here are:

* `pygeoprocessing.geoprocessing.numpy_array_to_raster` has been modified to make the pixel size and origin optional, as this spatial information is not needed for kernels.
* `pygeoprocessing.kernels.kernel_from_numpy_array` is simply a wrapper around `numpy_array_to_raster`, pre-filling in the parameters that kernels (and `convolve_2d`) don't care about.
* `pygeoprocessing.kernels.create_kernel` creates a distance-based kernel from a user-defined function.  The function may be a callable, or an `eval`-able string.
* A selection of common kernel functions are also provided.

I elected to create separate top-level functions for the various decay kernels in order to make it easier to inspect the required parameters and so that the user would only need to make a single function call.  Other approaches, like always defining functions as strings or always defining functions as functions of numpy arrays, require additional work to be able to use (string formatting and something like `functools.partial`, respectively).

Please let me know what you think, including about the names of the functions!

Fixes #268 