### PR TITLE
Replace `<lambda>` in geoprocessing progress logging with the function name

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,9 @@ Release History
 
 Unreleased Changes
 ------------------
+* Logging across functions in ``pygeoprocessing.geoprocessing`` now correctly
+  reports the function that it's being called from rather than ``<lambda>``.
+  https://github.com/natcap/pygeoprocessing/issues/300
 * The function ``pygeoprocessing.reproject_vector`` now accepts an optional
   parameter ``layer_name`` to allow the target vector layer name to be defined
   by the user.  If the user does not provide a ``layer_name``, the layer name

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -496,7 +496,7 @@ def raster_calculator(
                     '%s %.1f%% complete',
                     os.path.basename(target_raster_path),
                     float(pixels_processed) / n_pixels * 100.0,
-                    stack_level=3
+                    stacklevel=3
                 ),
                 _LOGGING_PERIOD)
 
@@ -650,7 +650,7 @@ def raster_reduce(function, raster_path_band, initializer, mask_nodata=True,
             last_time, lambda: LOGGER.info(
                 f'{raster_path_band[0]} reduce '
                 f'{pixels_processed / n_pixels * 100:.1f}%% complete',
-                stack_level=3
+                stacklevel=3
             ),
             _LOGGING_PERIOD)
 
@@ -1082,7 +1082,7 @@ def new_raster_from_base(
                         f'filling new raster {target_path} with {fill_value} '
                         f'-- {float(pixels_processed)/n_pixels*100.0:.2f}% '
                         f'complete',
-                        stack_level=3),
+                        stacklevel=3),
                     _LOGGING_PERIOD)
             target_band = None
     target_band = None
@@ -1511,7 +1511,7 @@ def zonal_statistics(
                 "zonal stats approximately %.1f%% complete on %s",
                 100.0 * float(set_index+1) / len(disjoint_fid_sets),
                 os.path.basename(aggregate_vector_path),
-                stack_level=3),
+                stacklevel=3),
             _LOGGING_PERIOD)
         disjoint_layer = disjoint_vector.CreateLayer(
             'disjoint_vector', spat_ref, ogr.wkbPolygon)
@@ -1527,7 +1527,7 @@ def zonal_statistics(
                     "on %s", set_index+1, len(disjoint_fid_sets),
                     100.0 * float(index+1) / len(disjoint_fid_set),
                     os.path.basename(aggregate_vector_path),
-                    stack_level=3),
+                    stacklevel=3),
                 _LOGGING_PERIOD)
             agg_feat = aggregate_layer.GetFeature(feature_fid)
             agg_geom_ref = agg_feat.GetGeometryRef()
@@ -2003,7 +2003,7 @@ def reproject_vector(
                 "reprojection approximately %.1f%% complete on %s",
                 100.0 * float(feature_index+1) / (layer.GetFeatureCount()),
                 os.path.basename(target_path),
-                stack_level=3),
+                stacklevel=3),
             _LOGGING_PERIOD)
 
         geom = base_feature.GetGeometryRef()
@@ -2568,7 +2568,7 @@ def calculate_disjoint_polygon_set(
                 "poly intersection lookup approximately %.1f%% complete "
                 "on %s", 100.0 * float(poly_index+1) / len(
                     shapely_polygon_lookup), os.path.basename(vector_path),
-                stack_level=3),
+                stacklevel=3),
             _LOGGING_PERIOD)
         possible_intersection_set = list(poly_rtree_index.intersection(
             poly_geom.bounds))
@@ -2611,7 +2611,7 @@ def calculate_disjoint_polygon_set(
                     "on %s", 100.0 * float(
                         feature_count - len(poly_intersect_lookup)) /
                     feature_count, os.path.basename(vector_path),
-                    stack_level=3),
+                    stacklevel=3),
                 _LOGGING_PERIOD)
             if not poly_intersect_set.intersection(maximal_set):
                 # no intersection, add poly_fid to the maximal set and remove

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2,7 +2,6 @@
 """A collection of raster and vector algorithms and utilities."""
 import collections
 import functools
-import inspect
 import logging
 import math
 import os
@@ -102,6 +101,10 @@ LOGGER.debug(
 
 class TimedLoggingAdapter(logging.LoggerAdapter):
     """A logging adapter to restrict logging based on a timer.
+
+    The objective is to have a ``logging.LOGGER``-like object that can be
+    called multiple times in rapid successtion, but with log messages only
+    propagating every X seconds.
 
     This object is helpful for creating consistency in logging callbacks and is
     derived from the python stdlib ``logging.LoggerAdapter``.

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -495,7 +495,9 @@ def raster_calculator(
                 last_time, lambda: LOGGER.info(
                     '%s %.1f%% complete',
                     os.path.basename(target_raster_path),
-                    float(pixels_processed) / n_pixels * 100.0),
+                    float(pixels_processed) / n_pixels * 100.0,
+                    stack_level=3
+                ),
                 _LOGGING_PERIOD)
 
         LOGGER.info('100.0% complete')
@@ -647,7 +649,9 @@ def raster_reduce(function, raster_path_band, initializer, mask_nodata=True,
         last_time = _invoke_timed_callback(
             last_time, lambda: LOGGER.info(
                 f'{raster_path_band[0]} reduce '
-                f'{pixels_processed / n_pixels * 100:.1f}%% complete'),
+                f'{pixels_processed / n_pixels * 100:.1f}%% complete',
+                stack_level=3
+            ),
             _LOGGING_PERIOD)
 
     LOGGER.info('100.0%% complete')
@@ -1077,7 +1081,8 @@ def new_raster_from_base(
                     last_time, lambda: LOGGER.info(
                         f'filling new raster {target_path} with {fill_value} '
                         f'-- {float(pixels_processed)/n_pixels*100.0:.2f}% '
-                        f'complete'),
+                        f'complete',
+                        stack_level=3),
                     _LOGGING_PERIOD)
             target_band = None
     target_band = None
@@ -1505,7 +1510,8 @@ def zonal_statistics(
             last_time, lambda: LOGGER.info(
                 "zonal stats approximately %.1f%% complete on %s",
                 100.0 * float(set_index+1) / len(disjoint_fid_sets),
-                os.path.basename(aggregate_vector_path)),
+                os.path.basename(aggregate_vector_path),
+                stack_level=3),
             _LOGGING_PERIOD)
         disjoint_layer = disjoint_vector.CreateLayer(
             'disjoint_vector', spat_ref, ogr.wkbPolygon)
@@ -1520,7 +1526,8 @@ def zonal_statistics(
                     "polygon set %d of %d approximately %.1f%% processed "
                     "on %s", set_index+1, len(disjoint_fid_sets),
                     100.0 * float(index+1) / len(disjoint_fid_set),
-                    os.path.basename(aggregate_vector_path)),
+                    os.path.basename(aggregate_vector_path),
+                    stack_level=3),
                 _LOGGING_PERIOD)
             agg_feat = aggregate_layer.GetFeature(feature_fid)
             agg_geom_ref = agg_feat.GetGeometryRef()
@@ -1995,7 +2002,8 @@ def reproject_vector(
             last_time, lambda: LOGGER.info(
                 "reprojection approximately %.1f%% complete on %s",
                 100.0 * float(feature_index+1) / (layer.GetFeatureCount()),
-                os.path.basename(target_path)),
+                os.path.basename(target_path),
+                stack_level=3),
             _LOGGING_PERIOD)
 
         geom = base_feature.GetGeometryRef()
@@ -2559,7 +2567,8 @@ def calculate_disjoint_polygon_set(
             last_time, lambda: LOGGER.info(
                 "poly intersection lookup approximately %.1f%% complete "
                 "on %s", 100.0 * float(poly_index+1) / len(
-                    shapely_polygon_lookup), os.path.basename(vector_path)),
+                    shapely_polygon_lookup), os.path.basename(vector_path),
+                stack_level=3),
             _LOGGING_PERIOD)
         possible_intersection_set = list(poly_rtree_index.intersection(
             poly_geom.bounds))
@@ -2601,7 +2610,8 @@ def calculate_disjoint_polygon_set(
                     "maximal subset build approximately %.1f%% complete "
                     "on %s", 100.0 * float(
                         feature_count - len(poly_intersect_lookup)) /
-                    feature_count, os.path.basename(vector_path)),
+                    feature_count, os.path.basename(vector_path),
+                    stack_level=3),
                 _LOGGING_PERIOD)
             if not poly_intersect_set.intersection(maximal_set):
                 # no intersection, add poly_fid to the maximal set and remove

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2,6 +2,7 @@
 """A collection of raster and vector algorithms and utilities."""
 import collections
 import functools
+import inspect
 import logging
 import math
 import os
@@ -130,11 +131,21 @@ class TimedLoggingAdapter(logging.LoggerAdapter):
         Returns:
             ``None``.
         """
-        # Don't override the user's defined stacklevel if present
-        # Otherwise, it's safe to assume that the target funcname is 3 stack
-        # frames above this one.
-        if 'stacklevel' not in kwargs:
-            kwargs['stacklevel'] = 3
+        # The stacklevel arg to logging was introduced to logging in python
+        # 3.8 and there isn't a clear way to spoof this in python 3.7, so
+        # ignore.
+        if sys.version_info >= (3, 8):
+            # Don't override user-defined stacklevel if present.
+            if 'stacklevel' not in kwargs:
+                # Based on logging internals, 3 is the expected stack depth.
+                kwargs['stacklevel'] = 3
+
+            # Python 3.11 modified the stacklevel argument to be more
+            # consistent with the behavior in the warnings module.
+            # https://github.com/python/cpython/issues/89334
+            if sys.version_info >= (3, 11):
+                kwargs['stacklevel'] -= 1
+
         now = time.time()
         if now >= self.last_time + self.interval:
             self.last_time = now

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import queue
 import shutil
+import sys
 import tempfile
 import time
 import types
@@ -1532,9 +1533,15 @@ class TestGeoprocessing(unittest.TestCase):
             self.assertEqual(record.msg, expected_message)
 
             # check that the function name logged is the name of this test
-            # (which is the calling function)
-            self.assertEqual(
-                record.funcName, self.test_timed_logging_adapter.__name__)
+            # (which is the calling function).  This is only possible on python
+            # 3.8 or later.
+            if sys.version_info >= (3, 8):
+                self.assertEqual(
+                    record.funcName, self.test_timed_logging_adapter.__name__)
+
+        # The rest of this test only applies to python 3.8+
+        if sys.version_info < (3, 8):
+            return
 
         # Check the custom stack frame adjustment
         with capture_logging(pygeoprocessing_logger) as captured_logging:

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -1541,7 +1541,7 @@ class TestGeoprocessing(unittest.TestCase):
             timed_logger = TimedLoggingAdapter(interval_s=0.1)
 
             def _sub_stackframe():
-                time.sleep(0.5) # make sure we pass the interval threshold
+                time.sleep(0.5)  # make sure we pass the interval threshold
                 # The 4 is 1 more than the default, so the message SHOULD
                 # report that the test called it.
                 timed_logger.critical('DANGER', stacklevel=4)

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -1556,7 +1556,9 @@ class TestGeoprocessing(unittest.TestCase):
             _sub_stackframe()
 
         self.assertEqual(len(captured_logging), 1)
-        self.assertEqual(captured_logging[0].msg, 'DANGER')
+
+        record = captured_logging[0]
+        self.assertEqual(record.msg, 'DANGER')
 
         # check that the function name logged is the name of this test
         # (which is the parent of the calling function)

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -1506,14 +1506,6 @@ class TestGeoprocessing(unittest.TestCase):
 
         numpy.testing.assert_array_equal(result_array, expected_result)
 
-    def test_invoke_timed_callback(self):
-        """PGP.geoprocessing: cover a timed callback."""
-        reference_time = time.time()
-        time.sleep(0.1)
-        new_time = pygeoprocessing.geoprocessing._invoke_timed_callback(
-            reference_time, lambda: None, 0.05)
-        self.assertNotEqual(reference_time, new_time)
-
     def test_timed_logging_adapter(self):
         """PGP.geoprocessing: check timed logging."""
         from pygeoprocessing.geoprocessing import TimedLoggingAdapter


### PR DESCRIPTION
This PR uses a new subclass of `logging.LoggerAdapter` to:

1. Handle logging that should only happen on a specified interval and
2. Make sure that the correct parameters are passed in to adjust the function name of the stack frame we want, not the default stack frame.

As far as logging itself goes, this PR transforms this:
```
2023-02-09 12:33:46,486:pid56575:INFO:pygeoprocessing.geoprocessing:raster_calculator:starting stats_worker
2023-02-09 12:33:46,486:pid56575:INFO:pygeoprocessing.geoprocessing:raster_calculator:started stats_worker <Thread(Thread-1, started daemon 12951224320)>
2023-02-09 12:33:51,536:pid56575:INFO:pygeoprocessing.geoprocessing:<lambda>:foo.tif 0.7% complete
```

into this:
```
2023-02-09 12:33:46,486:pid56575:INFO:pygeoprocessing.geoprocessing:raster_calculator:starting stats_worker
2023-02-09 12:33:46,486:pid56575:INFO:pygeoprocessing.geoprocessing:raster_calculator:started stats_worker <Thread(Thread-1, started daemon 12951224320)>
2023-02-09 12:33:51,536:pid56575:INFO:pygeoprocessing.geoprocessing:raster_calculator:foo.tif 0.7% complete
```

Although the simplest fix would have been to just add the stack frame adjustment to each timed logging call, that solution was both harder to test and meant that we had to remember to add the timed progress logging _with_ the appropriate parameters for the stack frame adjustment.  The solution here is easier to test and assumes a reasonable stack frame adjustment if the user hasn't already defined one.

After submitting the PR I also found a change in the `logging` API, where this isn't actually supported on python 3.7.  Rather than trying to sink some time into recreating later functionality, I opted to just skip this feature unless we're on python 3.8+.

Fixes #300