### PR TITLE
Update `zonal_statistics` to work on multiple raster layers

### DIFF
--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1373,7 +1373,7 @@ def zonal_statistics(
     raster for overlap statistics.
 
     Statistics are calculated on the set of pixels that fall within each
-    feature polygon. If `ignore_nodata` is false, nodata pixels are considered
+    feature polygon. If ``ignore_nodata`` is false, nodata pixels are considered
     valid when calculating the statistics:
 
     'min': minimum valid pixel value

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1765,6 +1765,7 @@ def zonal_statistics(
     # dereference gdal objects
     data_band, data_source, fid_raster = None, None, None
     disjoint_layer, aggregate_layer, aggregate_vector = None, None, None
+    target_layer, target_vector = None
 
     shutil.rmtree(temp_working_dir)
     if multi_raster_mode:

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1461,11 +1461,11 @@ def zonal_statistics(
     multi_raster_mode = isinstance(base_raster_path_band, list)
     if not multi_raster_mode:
         base_raster_path_band = [base_raster_path_band]
-    for base_raster_path_band in base_raster_path_band:
-        if not _is_raster_path_band_formatted(base_raster_path_band):
+    for path_band_tuple in base_raster_path_band:
+        if not _is_raster_path_band_formatted(path_band_tuple):
             raise ValueError(
                 '`base_raster_path_band` not formatted as expected.  Expected '
-                f'(path, band_index), received {repr(base_raster_path_band)}')
+                f'(path, band_index), received {repr(path_band_tuple)}')
 
     # Check that all input rasters are aligned. This should hold true if they
     # have the same projection, geotransform, and bounding box.

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1358,7 +1358,7 @@ def interpolate_points(
 
 
 def zonal_statistics(
-        base_raster_path_band_list, aggregate_vector_path,
+        base_raster_path_band, aggregate_vector_path,
         aggregate_layer_name=None, ignore_nodata=True,
         polygons_might_overlap=True, include_value_counts=False,
         working_dir=None):
@@ -1390,7 +1390,7 @@ def zonal_statistics(
         the description and dataset to jdouglass@stanford.edu.
 
     Args:
-        base_raster_path_band_list (tuple or list[tuple]): base raster
+        base_raster_path_band (tuple or list[tuple]): base raster
             (path, band) tuple(s) to analyze. If a list of multiple raster
             bands is provided, they must be aligned (all having the same
             bounding box, geotransform, and projection).

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1586,8 +1586,6 @@ def zonal_statistics(
             outputBounds=bbox_intersection,
             callback=_make_logger_callback("Warp %.1f%% complete %s"))
 
-    timed_logger = TimedLoggingAdapter(_LOGGING_PERIOD)
-
     # Calculate disjoint polygon sets
     if polygons_might_overlap:
         LOGGER.info('calculating disjoint polygon sets')
@@ -1625,6 +1623,8 @@ def zonal_statistics(
     # Calculate statistics for each raster and each feature
     # working block-wise through the rasters
     for i, (raster_path, band) in enumerate(target_raster_path_band_list):
+        LOGGER.info('calculating stats on raster '
+                    f'{i} of {len(target_raster_path_band_list)}')
         # fetch the block offsets before the raster is opened for writing
         offset_list = list(iterblocks((raster_path, band), offset_only=True))
         nodata = get_raster_info(raster_path)['nodata'][band - 1]
@@ -1632,7 +1632,9 @@ def zonal_statistics(
         data_band = data_source.GetRasterBand(band)
         found_fids = set()  # track FIDs that have been found on at least one pixel
 
-        for fid_raster_path in fid_raster_paths:
+        for set_index, fid_raster_path in enumerate(fid_raster_paths):
+            LOGGER.info(
+                f'disjoint polygon set {set_index} of {len(fid_raster_paths)}')
             fid_raster = gdal.OpenEx(fid_raster_path, gdal.OF_RASTER)
             fid_band = fid_raster.GetRasterBand(1)
 

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1765,7 +1765,7 @@ def zonal_statistics(
     # dereference gdal objects
     data_band, data_source, fid_raster = None, None, None
     disjoint_layer, aggregate_layer, aggregate_vector = None, None, None
-    target_layer, target_vector = None
+    target_layer, target_vector = None, None
 
     shutil.rmtree(temp_working_dir)
     if multi_raster_mode:

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1422,7 +1422,7 @@ def zonal_statistics(
             should be created during this run.
 
     Return:
-        If `base_raster_path_band_list` is a tuple, the return value is a nested
+        If `base_raster_path_band` is a tuple, the return value is a nested
         dictionary of stats for that raster band. Top-level keys are the
         aggregate feature FIDs. Each nested FID dictionary then contains
         statistics about that feature: 'min', 'max', 'sum', 'count',
@@ -1442,10 +1442,10 @@ def zonal_statistics(
                 }
             }
 
-        If `base_raster_path_band_list` is a list of tuples, the return value is
+        If `base_raster_path_band` is a list of tuples, the return value is
         a list of the nested dictionaries described above. Each dictionary in
         the list contains the stats calculated for the corresponding raster
-        band in the `base_raster_path_band_list` list.
+        band in the `base_raster_path_band` list.
 
 
     Raises:
@@ -1458,10 +1458,10 @@ def zonal_statistics(
 
     """
     # Check that the raster path/band input is formatted correctly
-    multi_raster_mode = isinstance(base_raster_path_band_list, list)
+    multi_raster_mode = isinstance(base_raster_path_band, list)
     if not multi_raster_mode:
-        base_raster_path_band_list = [base_raster_path_band_list]
-    for base_raster_path_band in base_raster_path_band_list:
+        base_raster_path_band = [base_raster_path_band]
+    for base_raster_path_band in base_raster_path_band:
         if not _is_raster_path_band_formatted(base_raster_path_band):
             raise ValueError(
                 '`base_raster_path_band` not formatted as expected.  Expected '
@@ -1471,7 +1471,7 @@ def zonal_statistics(
     # have the same projection, geotransform, and bounding box.
     for attr in ['geotransform', 'bounding_box', 'projection_wkt']:
         vals = set()
-        for path, _ in base_raster_path_band_list:
+        for path, _ in base_raster_path_band:
             raster_info = get_raster_info(path)
             vals.add(str(raster_info[attr]))
         if len(vals) > 1:
@@ -1518,7 +1518,7 @@ def zonal_statistics(
     fid_field_name = 'original_fid'
     target_layer.CreateField(ogr.FieldDefn(fid_field_name, ogr.OFTInteger))
     valid_fid_set = set()
-    aggregate_stats_list = [{} for _ in base_raster_path_band_list]
+    aggregate_stats_list = [{} for _ in base_raster_path_band]
     for feature in aggregate_layer:
         fid = feature.GetFID()
         # Initialize the output data structure:
@@ -1570,7 +1570,7 @@ def zonal_statistics(
 
     # Clip base rasters to their intersection with the aggregate vector
     target_raster_path_band_list = []
-    for i, (base_path, band) in enumerate(base_raster_path_band_list):
+    for i, (base_path, band) in enumerate(base_raster_path_band):
         raster_info = get_raster_info(path)
         if (raster_info['datatype'] in {gdal.GDT_Float32, gdal.GDT_Float64}
                 and include_value_counts):

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1386,8 +1386,9 @@ def zonal_statistics(
     Note:
         There may be some degenerate cases where the bounding box vs. actual
         geometry intersection would be incorrect, but these are so unlikely as
-        to be manually constructed. If you encounter one of these please email
-        the description and dataset to jdouglass@stanford.edu.
+        to be manually constructed. If you encounter one of these please create
+        an issue at https://github.com/natcap/pygeoprocessing/issues with the
+        datasets used.
 
     Args:
         base_raster_path_band_list (tuple or list[tuple]): base raster

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -896,10 +896,10 @@ class TestGeoprocessing(unittest.TestCase):
         layer_defn = layer.GetLayerDefn()
 
         # make an n x n raster with 2*m x 2*m polygons inside.
-        pixel_size = 1.0
-        subpixel_size = 1./5. * pixel_size
-        origin_x = 1.0
-        origin_y = -1.0
+        pixel_size = 1
+        subpixel_size = pixel_size / 5
+        origin_x = 1
+        origin_y = -1
         n = 16
         layer.StartTransaction()
         for row_index in range(n * 2):
@@ -936,7 +936,7 @@ class TestGeoprocessing(unittest.TestCase):
             pixel_size=(pixel_size, -pixel_size))
 
         zonal_stats = pygeoprocessing.zonal_statistics(
-            [(raster_path, 1)], vector_path)[0]
+            (raster_path, 1), vector_path)
         self.assertEqual(len(zonal_stats), 4*n*n + 1)
         for poly_id in zonal_stats:
             feature = layer.GetFeature(poly_id)
@@ -956,10 +956,10 @@ class TestGeoprocessing(unittest.TestCase):
         layer_defn = layer.GetLayerDefn()
 
         # make an n x n raster with 2*m x 2*m polygons inside.
-        pixel_size = 1.0
-        subpixel_size = 1./5. * pixel_size
-        origin_x = 1.0
-        origin_y = -1.0
+        pixel_size = 1
+        subpixel_size = pixel_size / 5
+        origin_x = 1
+        origin_y = -1
         n = 16
         layer.StartTransaction()
         x_pos = origin_x - n
@@ -985,9 +985,9 @@ class TestGeoprocessing(unittest.TestCase):
             -1, raster_path)
 
         zonal_stats = pygeoprocessing.zonal_statistics(
-            [(raster_path, 1)], vector_path)[0]
+            (raster_path, 1), vector_path)
         for poly_id in zonal_stats:
-            self.assertEqual(zonal_stats[poly_id]['sum'], 0.0)
+            self.assertEqual(zonal_stats[poly_id]['sum'], 0)
 
     def test_zonal_stats_all_outside(self):
         """PGP.geoprocessing: test vector all outside raster."""
@@ -1001,10 +1001,10 @@ class TestGeoprocessing(unittest.TestCase):
         layer_defn = layer.GetLayerDefn()
 
         # make an n x n raster with 2*m x 2*m polygons inside.
-        pixel_size = 1.0
-        subpixel_size = 1./5. * pixel_size
-        origin_x = 1.0
-        origin_y = -1.0
+        pixel_size = 1
+        subpixel_size = pixel_size / 5
+        origin_x = 1
+        origin_y = -1
         n = 16
         layer.StartTransaction()
         x_pos = origin_x - n
@@ -1068,9 +1068,9 @@ class TestGeoprocessing(unittest.TestCase):
         _array_to_raster(array, -1, raster_path)
 
         zonal_stats = pygeoprocessing.zonal_statistics(
-            [(raster_path, 1)], vector_path)[0]
+            (raster_path, 1), vector_path)
         for poly_id in zonal_stats:
-            self.assertEqual(zonal_stats[poly_id]['sum'], 0.0)
+            self.assertEqual(zonal_stats[poly_id]['sum'], 0)
 
         # this will catch a polygon that barely intersects the upper left
         # hand corner but is nodata.
@@ -1079,13 +1079,13 @@ class TestGeoprocessing(unittest.TestCase):
         array = numpy.fliplr(numpy.flipud(
             numpy.array(range(n*n), dtype=numpy.int32).reshape((n, n))))
         _array_to_raster(
-            array, None, raster_path, projection_epsg=4326,
-            origin=(origin_x+n, origin_y-n), pixel_size=(-1, 1))
+            array, 255, raster_path, projection_epsg=4326,
+            origin=(origin_x+n, origin_y-n), pixel_size=(1, -1))
 
         zonal_stats = pygeoprocessing.zonal_statistics(
-            [(raster_path, 1)], vector_path)[0]
+            (raster_path, 1), vector_path)
         for poly_id in zonal_stats:
-            self.assertEqual(zonal_stats[poly_id]['sum'], 0.0)
+            self.assertEqual(zonal_stats[poly_id]['sum'], 0)
 
     def test_mask_raster(self):
         """PGP.geoprocessing: test mask raster."""
@@ -1178,11 +1178,11 @@ class TestGeoprocessing(unittest.TestCase):
         _array_to_raster(
             pixel_matrix, target_nodata, raster_path)
         result = pygeoprocessing.zonal_statistics(
-            [(raster_path, 1)], aggregating_vector_path,
+            (raster_path, 1), aggregating_vector_path,
             aggregate_layer_name=None,
             ignore_nodata=True,
             polygons_might_overlap=True)
-        expected_result = [{
+        expected_result = {
             0: {
                 'count': 81,
                 'max': 1.0,
@@ -1200,7 +1200,7 @@ class TestGeoprocessing(unittest.TestCase):
                 'max': None,
                 'count': 0,
                 'nodata_count': 0,
-                'sum': 0.0}}]
+                'sum': 0.0}}
         self.assertEqual(result, expected_result)
 
     def test_zonal_statistics_value_counts(self):
@@ -1242,7 +1242,7 @@ class TestGeoprocessing(unittest.TestCase):
         with capture_logging(
                 logging.getLogger('pygeoprocessing')) as log_messages:
             result = pygeoprocessing.zonal_statistics(
-                [(raster_path, 1)], aggregating_vector_path,
+                (raster_path, 1), aggregating_vector_path,
                 aggregate_layer_name=None,
                 ignore_nodata=True,
                 include_value_counts=True,
@@ -1253,7 +1253,7 @@ class TestGeoprocessing(unittest.TestCase):
         self.assertEqual(log_messages[0].levelno, logging.WARNING)
         self.assertIn('Value counts requested on a floating-point raster',
                       log_messages[0].msg)
-        expected_result = [{
+        expected_result = {
             0: {
                 'count': 81,
                 'max': 1.0,
@@ -1275,7 +1275,7 @@ class TestGeoprocessing(unittest.TestCase):
                 'nodata_count': 0,
                 'sum': 0.0,
                 'value_counts': {}}
-        }]
+        }
         self.assertEqual(result, expected_result)
 
     def test_zonal_statistics_nodata(self):
@@ -1305,17 +1305,17 @@ class TestGeoprocessing(unittest.TestCase):
         _array_to_raster(
             pixel_matrix, target_nodata, raster_path)
         result = pygeoprocessing.zonal_statistics(
-            [(raster_path, 1)], aggregating_vector_path,
+            (raster_path, 1), aggregating_vector_path,
             aggregate_layer_name=None,
             ignore_nodata=True,
             polygons_might_overlap=False)
-        expected_result = [{
+        expected_result = {
             0: {
                 'count': 0,
                 'max': None,
                 'min': None,
                 'nodata_count': 81,
-                'sum': 0.0}}]
+                'sum': 0.0}}
         self.assertEqual(result, expected_result)
 
     def test_zonal_statistics_nodata_is_zero(self):
@@ -1338,20 +1338,21 @@ class TestGeoprocessing(unittest.TestCase):
         raster_path = os.path.join(self.workspace_dir, 'small_raster.tif')
         _array_to_raster(
             numpy.array([[1, 0], [1, 0]], dtype=numpy.int32), 0, raster_path,
-            origin=(origin_x, origin_y), pixel_size=(1.0, -1.0))
+            origin=(origin_x, origin_y), pixel_size=(1.0, -1.0),
+            projection_epsg=4326)
 
         result = pygeoprocessing.zonal_statistics(
-            [(raster_path, 1)], vector_path,
+            (raster_path, 1), vector_path,
             aggregate_layer_name=None,
             ignore_nodata=True,
             polygons_might_overlap=False)
-        expected_result = [{
+        expected_result = {
             1: {
                 'count': 2,
                 'max': 1,
                 'min': 1,
                 'nodata_count': 2,
-                'sum': 2.0}}]
+                'sum': 2.0}}
         self.assertEqual(result, expected_result)
 
     def test_zonal_statistics_named_layer(self):
@@ -1378,17 +1379,17 @@ class TestGeoprocessing(unittest.TestCase):
         _array_to_raster(
             pixel_matrix, target_nodata, raster_path)
         result = pygeoprocessing.zonal_statistics(
-            [(raster_path, 1)], aggregating_vector_path,
+            (raster_path, 1), aggregating_vector_path,
             aggregate_layer_name='aggregate_vector',
             ignore_nodata=True,
             polygons_might_overlap=True)
-        expected_result = [{
+        expected_result = {
             0: {
                 'count': 81,
                 'max': 1.0,
                 'min': 1.0,
                 'nodata_count': 0,
-                'sum': 81.0}}]
+                'sum': 81.0}}
         self.assertEqual(result, expected_result)
 
     def test_zonal_statistics_bad_vector(self):
@@ -1404,7 +1405,7 @@ class TestGeoprocessing(unittest.TestCase):
             pixel_matrix, target_nodata, raster_path)
         with self.assertRaises(RuntimeError) as cm:
             _ = pygeoprocessing.zonal_statistics(
-                [(raster_path, 1)], missing_aggregating_vector_path,
+                (raster_path, 1), missing_aggregating_vector_path,
                 ignore_nodata=True,
                 polygons_might_overlap=True)
         expected_message = 'Could not open aggregate vector'
@@ -1427,7 +1428,7 @@ class TestGeoprocessing(unittest.TestCase):
             vector_format='ESRI Shapefile')
         with self.assertRaises(RuntimeError) as cm:
             _ = pygeoprocessing.zonal_statistics(
-                [(raster_path, 1)], aggregating_vector_path,
+                (raster_path, 1), aggregating_vector_path,
                 ignore_nodata=True,
                 aggregate_layer_name='not a layer name',
                 polygons_might_overlap=True)
@@ -1469,7 +1470,7 @@ class TestGeoprocessing(unittest.TestCase):
         with self.assertRaises(ValueError):
             # intentionally not passing a (path, band) tuple as first arg
             _ = pygeoprocessing.zonal_statistics(
-                [raster_path], aggregating_vector_path,
+                raster_path, aggregating_vector_path,
                 aggregate_layer_name=None,
                 ignore_nodata=True,
                 polygons_might_overlap=True)

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -936,7 +936,7 @@ class TestGeoprocessing(unittest.TestCase):
             pixel_size=(pixel_size, -pixel_size))
 
         zonal_stats = pygeoprocessing.zonal_statistics(
-            (raster_path, 1), vector_path)
+            [(raster_path, 1)], vector_path)[0]
         self.assertEqual(len(zonal_stats), 4*n*n + 1)
         for poly_id in zonal_stats:
             feature = layer.GetFeature(poly_id)
@@ -985,7 +985,7 @@ class TestGeoprocessing(unittest.TestCase):
             -1, raster_path)
 
         zonal_stats = pygeoprocessing.zonal_statistics(
-            (raster_path, 1), vector_path)
+            [(raster_path, 1)], vector_path)[0]
         for poly_id in zonal_stats:
             self.assertEqual(zonal_stats[poly_id]['sum'], 0.0)
 
@@ -1068,7 +1068,7 @@ class TestGeoprocessing(unittest.TestCase):
         _array_to_raster(array, -1, raster_path)
 
         zonal_stats = pygeoprocessing.zonal_statistics(
-            (raster_path, 1), vector_path)
+            [(raster_path, 1)], vector_path)[0]
         for poly_id in zonal_stats:
             self.assertEqual(zonal_stats[poly_id]['sum'], 0.0)
 
@@ -1083,7 +1083,7 @@ class TestGeoprocessing(unittest.TestCase):
             origin=(origin_x+n, origin_y-n), pixel_size=(-1, 1))
 
         zonal_stats = pygeoprocessing.zonal_statistics(
-            (raster_path, 1), vector_path)
+            [(raster_path, 1)], vector_path)[0]
         for poly_id in zonal_stats:
             self.assertEqual(zonal_stats[poly_id]['sum'], 0.0)
 
@@ -1178,11 +1178,11 @@ class TestGeoprocessing(unittest.TestCase):
         _array_to_raster(
             pixel_matrix, target_nodata, raster_path)
         result = pygeoprocessing.zonal_statistics(
-            (raster_path, 1), aggregating_vector_path,
+            [(raster_path, 1)], aggregating_vector_path,
             aggregate_layer_name=None,
             ignore_nodata=True,
             polygons_might_overlap=True)
-        expected_result = {
+        expected_result = [{
             0: {
                 'count': 81,
                 'max': 1.0,
@@ -1200,7 +1200,7 @@ class TestGeoprocessing(unittest.TestCase):
                 'max': None,
                 'count': 0,
                 'nodata_count': 0,
-                'sum': 0.0}}
+                'sum': 0.0}}]
         self.assertEqual(result, expected_result)
 
     def test_zonal_statistics_value_counts(self):
@@ -1242,7 +1242,7 @@ class TestGeoprocessing(unittest.TestCase):
         with capture_logging(
                 logging.getLogger('pygeoprocessing')) as log_messages:
             result = pygeoprocessing.zonal_statistics(
-                (raster_path, 1), aggregating_vector_path,
+                [(raster_path, 1)], aggregating_vector_path,
                 aggregate_layer_name=None,
                 ignore_nodata=True,
                 include_value_counts=True,
@@ -1253,7 +1253,7 @@ class TestGeoprocessing(unittest.TestCase):
         self.assertEqual(log_messages[0].levelno, logging.WARNING)
         self.assertIn('Value counts requested on a floating-point raster',
                       log_messages[0].msg)
-        expected_result = {
+        expected_result = [{
             0: {
                 'count': 81,
                 'max': 1.0,
@@ -1275,7 +1275,7 @@ class TestGeoprocessing(unittest.TestCase):
                 'nodata_count': 0,
                 'sum': 0.0,
                 'value_counts': {}}
-        }
+        }]
         self.assertEqual(result, expected_result)
 
     def test_zonal_statistics_nodata(self):
@@ -1305,17 +1305,17 @@ class TestGeoprocessing(unittest.TestCase):
         _array_to_raster(
             pixel_matrix, target_nodata, raster_path)
         result = pygeoprocessing.zonal_statistics(
-            (raster_path, 1), aggregating_vector_path,
+            [(raster_path, 1)], aggregating_vector_path,
             aggregate_layer_name=None,
             ignore_nodata=True,
             polygons_might_overlap=False)
-        expected_result = {
+        expected_result = [{
             0: {
                 'count': 0,
                 'max': None,
                 'min': None,
                 'nodata_count': 81,
-                'sum': 0.0}}
+                'sum': 0.0}}]
         self.assertEqual(result, expected_result)
 
     def test_zonal_statistics_nodata_is_zero(self):
@@ -1341,17 +1341,17 @@ class TestGeoprocessing(unittest.TestCase):
             origin=(origin_x, origin_y), pixel_size=(1.0, -1.0))
 
         result = pygeoprocessing.zonal_statistics(
-            (raster_path, 1), vector_path,
+            [(raster_path, 1)], vector_path,
             aggregate_layer_name=None,
             ignore_nodata=True,
             polygons_might_overlap=False)
-        expected_result = {
+        expected_result = [{
             1: {
                 'count': 2,
                 'max': 1,
                 'min': 1,
                 'nodata_count': 2,
-                'sum': 2.0}}
+                'sum': 2.0}}]
         self.assertEqual(result, expected_result)
 
     def test_zonal_statistics_named_layer(self):
@@ -1378,17 +1378,17 @@ class TestGeoprocessing(unittest.TestCase):
         _array_to_raster(
             pixel_matrix, target_nodata, raster_path)
         result = pygeoprocessing.zonal_statistics(
-            (raster_path, 1), aggregating_vector_path,
+            [(raster_path, 1)], aggregating_vector_path,
             aggregate_layer_name='aggregate_vector',
             ignore_nodata=True,
             polygons_might_overlap=True)
-        expected_result = {
+        expected_result = [{
             0: {
                 'count': 81,
                 'max': 1.0,
                 'min': 1.0,
                 'nodata_count': 0,
-                'sum': 81.0}}
+                'sum': 81.0}}]
         self.assertEqual(result, expected_result)
 
     def test_zonal_statistics_bad_vector(self):
@@ -1404,7 +1404,7 @@ class TestGeoprocessing(unittest.TestCase):
             pixel_matrix, target_nodata, raster_path)
         with self.assertRaises(RuntimeError) as cm:
             _ = pygeoprocessing.zonal_statistics(
-                (raster_path, 1), missing_aggregating_vector_path,
+                [(raster_path, 1)], missing_aggregating_vector_path,
                 ignore_nodata=True,
                 polygons_might_overlap=True)
         expected_message = 'Could not open aggregate vector'
@@ -1427,7 +1427,7 @@ class TestGeoprocessing(unittest.TestCase):
             vector_format='ESRI Shapefile')
         with self.assertRaises(RuntimeError) as cm:
             _ = pygeoprocessing.zonal_statistics(
-                (raster_path, 1), aggregating_vector_path,
+                [(raster_path, 1)], aggregating_vector_path,
                 ignore_nodata=True,
                 aggregate_layer_name='not a layer name',
                 polygons_might_overlap=True)
@@ -1469,7 +1469,7 @@ class TestGeoprocessing(unittest.TestCase):
         with self.assertRaises(ValueError):
             # intentionally not passing a (path, band) tuple as first arg
             _ = pygeoprocessing.zonal_statistics(
-                raster_path, aggregating_vector_path,
+                [raster_path], aggregating_vector_path,
                 aggregate_layer_name=None,
                 ignore_nodata=True,
                 polygons_might_overlap=True)


### PR DESCRIPTION
Fixes #310 

This ended up being a pretty big refactor of the first half of zonal_statistics. It also fixes #306, another bug where some of the logged progress numbers didn't add up, and at least one other previously unreported bug (see test comment below).

As implemented, the old API is still valid and you can still provide a single raster band, so we won't need to make any changes to invest.