### PR TITLE
Expose `array_equals_nodata` function in api and add tests for it

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,6 +13,9 @@ Unreleased Changes
   the end of the function, resulting in excess memory usage and a warning
   during the shutdown of the python process.
   https://github.com/natcap/pygeoprocessing/issues/247
+* Added a new function, ``pygeoprocessing.array_equals_nodata``, which returns
+  a boolean array indicating which elements have nodata. It handles integer,
+  float, and ``nan`` comparison, and the case where the nodata value is `None`.
 
 2.4.0 (2023-03-03)
 ------------------

--- a/src/pygeoprocessing/__init__.py
+++ b/src/pygeoprocessing/__init__.py
@@ -15,6 +15,7 @@ except ImportError:
 from . import geoprocessing
 from .geoprocessing import _assert_is_valid_pixel_size
 from .geoprocessing import align_and_resize_raster_stack
+from .geoprocessing import array_equals_nodata
 from .geoprocessing import build_overviews
 from .geoprocessing import calculate_disjoint_polygon_set
 from .geoprocessing import convolve_2d

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -5151,8 +5151,6 @@ class TestGeoprocessing(unittest.TestCase):
 
     def test_integer_array(self):
         """PGP: array_equals_nodata returns integer array as expected."""
-        from natcap.invest import utils
-
         nodata_values = [9, 9.0]
 
         int_array = numpy.array(
@@ -5161,27 +5159,23 @@ class TestGeoprocessing(unittest.TestCase):
         expected_array = numpy.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])
 
         for nodata in nodata_values:
-            result_array = utils.array_equals_nodata(int_array, nodata)
+            result_array = pygeoprocessing.array_equals_nodata(int_array, nodata)
             numpy.testing.assert_array_equal(result_array, expected_array)
 
     def test_nan_nodata_array(self):
         """PGP: test array_equals_nodata with numpy.nan nodata values."""
-        from natcap.invest import utils
-
         array = numpy.array(
             [[4, 2, numpy.nan], [1, numpy.nan, 3], [numpy.nan, 6, 1]])
 
         expected_array = numpy.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])
 
-        result_array = utils.array_equals_nodata(array, numpy.nan)
+        result_array = pygeoprocessing..array_equals_nodata(array, numpy.nan)
         numpy.testing.assert_array_equal(result_array, expected_array)
 
     def test_none_nodata(self):
         """PGP: test array_equals_nodata when nodata is undefined (None)."""
-        from natcap.invest import utils
-
         array = numpy.array(
             [[4, 2, numpy.nan], [1, numpy.nan, 3], [numpy.nan, 6, 1]])
-        result_array = utils.array_equals_nodata(array, None)
+        result_array = pygeoprocessing.array_equals_nodata(array, None)
         numpy.testing.assert_array_equal(
             result_array, numpy.zeros(array.shape, dtype=bool))

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -5169,7 +5169,7 @@ class TestGeoprocessing(unittest.TestCase):
 
         expected_array = numpy.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])
 
-        result_array = pygeoprocessing..array_equals_nodata(array, numpy.nan)
+        result_array = pygeoprocessing.array_equals_nodata(array, numpy.nan)
         numpy.testing.assert_array_equal(result_array, expected_array)
 
     def test_none_nodata(self):

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -5148,3 +5148,40 @@ class TestGeoprocessing(unittest.TestCase):
         # The ordering of x, y is reversed from the numpy array shape.
         self.assertEqual(
             raster_info['overviews'], [(500, 1000), (250, 500)])
+
+    def test_integer_array(self):
+        """PGP: array_equals_nodata returns integer array as expected."""
+        from natcap.invest import utils
+
+        nodata_values = [9, 9.0]
+
+        int_array = numpy.array(
+            [[4, 2, 9], [1, 9, 3], [9, 6, 1]], dtype=numpy.int16)
+
+        expected_array = numpy.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])
+
+        for nodata in nodata_values:
+            result_array = utils.array_equals_nodata(int_array, nodata)
+            numpy.testing.assert_array_equal(result_array, expected_array)
+
+    def test_nan_nodata_array(self):
+        """PGP: test array_equals_nodata with numpy.nan nodata values."""
+        from natcap.invest import utils
+
+        array = numpy.array(
+            [[4, 2, numpy.nan], [1, numpy.nan, 3], [numpy.nan, 6, 1]])
+
+        expected_array = numpy.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])
+
+        result_array = utils.array_equals_nodata(array, numpy.nan)
+        numpy.testing.assert_array_equal(result_array, expected_array)
+
+    def test_none_nodata(self):
+        """PGP: test array_equals_nodata when nodata is undefined (None)."""
+        from natcap.invest import utils
+
+        array = numpy.array(
+            [[4, 2, numpy.nan], [1, numpy.nan, 3], [numpy.nan, 6, 1]])
+        result_array = utils.array_equals_nodata(array, None)
+        numpy.testing.assert_array_equal(
+            result_array, numpy.zeros(array.shape, dtype=bool))


### PR DESCRIPTION
In preparation for https://github.com/natcap/invest/issues/1213, this PR adds `array_equals_nodata` to the `geoprocessing` API, and copies over its tests from invest.