### PR TITLE
testing imports: check if `pygeoprocessing.__all__` members are callable rather than checking specific types

### DIFF
--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -133,15 +133,14 @@ class TestGeoprocessing(unittest.TestCase):
         # raises a SyntaxWarning.  Instead, I'll just ensure that every
         # attribute in pygeoprocessing.__all__ is a function that is available
         # at the pygeoprocessing level.
-        import inspect
         for attrname in pygeoprocessing.__all__:
             try:
                 func = getattr(pygeoprocessing, attrname)
-                self.assertTrue(
-                    isinstance(func, (
-                        types.FunctionType, types.BuiltinFunctionType)) or
-                    issubclass(func, Exception) or
-                    inspect.isroutine(func))
+                try:
+                    _ = getattr(func, '__call__')
+                except AttributeError:
+                    self.fail(('Function %s is in pygeoprocessing.__all__ but '
+                               'is not a callable') % attrname)
             except AttributeError:
                 self.fail(('Function %s is in pygeoprocessing.__all__ but '
                            'is not exposed at the package level') % attrname)


### PR DESCRIPTION
Fixes #328 

Here's a proposed solution, anyway. I'm not sure if this is exactly equivalent to the prior test, but it's agnostic to Cython versions & types, and seems to support the `__init__` construction of `__all__`.