### PR TITLE
standardizing approaches across `warp_raster` and `create_raster_from_bounding_box`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,10 @@ Unreleased Changes
 * Added a new function, ``pygeoprocessing.array_equals_nodata``, which returns
   a boolean array indicating which elements have nodata. It handles integer,
   float, and ``nan`` comparison, and the case where the nodata value is `None`.
+* Standardized the approach used in ``warp_raster`` and 
+  ``create_raster_from_bounding_box`` for determining the dimensions of the
+  target raster given a target bounding box and pixel sizes.
+  https://github.com/natcap/pygeoprocessing/issues/321
 
 2.4.0 (2023-03-03)
 ------------------

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1266,7 +1266,7 @@ def create_raster_from_bounding_box(
     target_y_size = int(abs(
         float(bbox_maxy - bbox_miny) / target_pixel_size[1]))
     x_residual = (
-        abs(target_x_size[0] * target_pixel_size[0]) -
+        abs(target_x_size * target_pixel_size[0]) -
         (bbox_maxx - bbox_minx))
     if not numpy.isclose(x_residual, 0.0):
         target_x_size += 1


### PR DESCRIPTION
Fixes #321 

This PR takes the approach we already use in `warp_raster` for determining a target raster size and applies it in `create_raster_from_bounding_box`. I thought about pulling this out to a function, but so far it only appears twice and is generally more readable when it's all inline, in my opinion.
