### PR TITLE
zonal stats: look up features by FID, not attribute filter #331

### DIFF
--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1492,6 +1492,7 @@ def zonal_statistics(
         raise RuntimeError(
             f"Could not open layer {aggregate_layer_name} of {aggregate_vector_path}")
 
+
     # Define the default/empty statistics values
     # These values will be returned for features that have no geometry or
     # don't overlap any valid pixels.
@@ -1537,7 +1538,7 @@ def zonal_statistics(
         feature_copy.SetField(fid_field_name, fid)
         target_layer.CreateFeature(feature_copy)
         original_to_new_fid_map[fid] = feature_copy.GetFID()
-    target_layer, target_vector, feature,  = None, None, None
+    target_layer, target_vector, feature, feature_copy = None, None, None, None
     geom_ref, aggregate_layer, aggregate_vector = None, None, None
 
     # Reproject the vector to match the raster projection
@@ -1680,7 +1681,7 @@ def zonal_statistics(
                         aggregate_stats_list[i][fid]['value_counts'].update(
                             dict(zip(*numpy.unique(
                                 feature_data, return_counts=True))))
-
+        fid_band, fid_raster = None, None
         # Handle edge cases: features that have a geometry but do not
         # overlap the center point of any pixel will not be captured by the
         # method above.
@@ -1769,9 +1770,8 @@ def zonal_statistics(
             f'all done processing polygon sets for {os.path.basename(aggregate_vector_path)}')
 
     # dereference gdal objects
-    data_band, data_source, fid_raster = None, None, None
-    disjoint_layer, aggregate_layer, aggregate_vector = None, None, None
-    target_layer, target_vector = None, None
+    data_band, data_source = None, None
+    disjoint_layer, target_layer, target_vector = None, None, None
 
     shutil.rmtree(temp_working_dir)
     if multi_raster_mode:

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -1191,6 +1191,63 @@ class TestGeoprocessing(unittest.TestCase):
              '"bounding_box" were found among the input rasters'),
             actual_message, actual_message)
 
+    def test_zonal_stats_empty_geometry(self):
+        """PGP.geoprocessing: zonal_statistics with an empty geometry."""
+        pixel_size = 30
+        n_pixels = 9
+        origin = (444720, 3751320)
+        polygon_a = shapely.geometry.Polygon([
+            (origin[0], origin[1]),
+            (origin[0], -pixel_size * n_pixels+origin[1]),
+            (origin[0]+pixel_size * n_pixels,
+             -pixel_size * n_pixels+origin[1]),
+            (origin[0]+pixel_size * n_pixels, origin[1]),
+            (origin[0], origin[1])])
+        polygon_b = shapely.geometry.Polygon([
+            (origin[0], origin[1]),
+            (origin[0], -pixel_size+origin[1]),
+            (origin[0]+pixel_size, -pixel_size+origin[1]),
+            (origin[0]+pixel_size, origin[1]),
+            (origin[0], origin[1])])
+        aggregating_vector_path = os.path.join(self.workspace_dir, 'aggregate_vector')
+        _geometry_to_vector(
+            [polygon_a, polygon_b], aggregating_vector_path)
+
+        aggregate_vector = gdal.OpenEx(aggregating_vector_path, gdal.OF_UPDATE)
+        aggregate_layer = aggregate_vector.GetLayer()
+        feat = aggregate_layer.GetFeature(0)  # feature with FID 0
+        feat.SetGeometry(None)
+        aggregate_layer.SetFeature(feat)
+        feat, aggregate_layer, aggregate_vector = None, None, None
+
+        pixel_matrix = numpy.ones((n_pixels, n_pixels), numpy.float32)
+        target_nodata = None
+        raster_path = os.path.join(self.workspace_dir, 'raster.tif')
+        _array_to_raster(
+            pixel_matrix, target_nodata, raster_path)
+        result = pygeoprocessing.zonal_statistics(
+            (raster_path, 1), aggregating_vector_path,
+            aggregate_layer_name=None,
+            ignore_nodata=True,
+            polygons_might_overlap=True)
+        # the empty geometry FID should be included with default results
+        # the FIDs should be preserved
+        expected_result = {
+            0: {
+                'min': None,
+                'max': None,
+                'count': 0,
+                'nodata_count': 0,
+                'sum': 0},
+            1: {
+                'count': 81,
+                'max': 1.0,
+                'min': 1.0,
+                'nodata_count': 0,
+                'sum': 81.0}}
+        self.assertEqual(result, expected_result)
+
+
     def test_mask_raster(self):
         """PGP.geoprocessing: test mask raster."""
         origin_x = 1.0


### PR DESCRIPTION
Fixes #331 

Looking up features by FID, rather than `GetNextFeature()` on a layer with an attribute filter, improves the performance a lot. I'm guessing that the attribute filter feature is not optimized like I'd hoped. `GetNextFeature()` probably just goes through all features in order until it finds one matching the attribute filter, which explains my observation that it became slower with each iteration - the matching feature was further along each time.

Also dereferencing a couple of GDAL objects that I missed before.

