### PR TITLE
Expose overview level to use in `warp_raster`

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -69,7 +69,7 @@ jobs:
           condarc: |
               channels:
                 - conda-forge
-          create-args: |
+          create-args: >-
               python=${{ matrix.python-version }}
               gdal=${{ matrix.gdal }}
               setuptools

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 0
 
       - name: setup-micromamba
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           # Grab requirements from pip-compatible requirements.txt
           environment-file: requirements.txt

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -66,6 +66,9 @@ jobs:
         with:
           # Grab requirements from pip-compatible requirements.txt
           environment-file: requirements.txt
+          condarc: |
+              channels:
+                - conda-forge
           create-args: |
               python=${{ matrix.python-version }}
               gdal=${{ matrix.gdal }}
@@ -74,7 +77,6 @@ jobs:
               flake8
               pytest
           environment-name: pyenv
-          channels: conda-forge
 
       - name: Lint with flake8
         run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           # Grab requirements from pip-compatible requirements.txt
           environment-file: requirements.txt
-          extra-specs: |
+          create-args: |
               python=${{ matrix.python-version }}
               gdal=${{ matrix.gdal }}
               setuptools

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,12 @@ Unreleased Changes
 * Added a new function, ``pygeoprocessing.array_equals_nodata``, which returns
   a boolean array indicating which elements have nodata. It handles integer,
   float, and ``nan`` comparison, and the case where the nodata value is `None`.
+* Users may now specify the overview level to use when calling ``warp_raster``.
+  By default, ``pygeoprocessing`` will use the base layer.
+  https://github.com/natcap/pygeoprocessing/issues/326
+* Fixed a bug across ``pygeoprocessing`` where some valid resampling methods
+  would throw an exception because they were not recognized.  This was only
+  happening when ``pygeoprocessing`` was installed alongside GDAL < 3.4.
 
 2.4.0 (2023-03-03)
 ------------------

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2196,7 +2196,7 @@ def warp_raster(
         base_raster_path, target_pixel_size, target_raster_path,
         resample_method, target_bb=None, base_projection_wkt=None,
         target_projection_wkt=None, n_threads=None, vector_mask_options=None,
-        gdal_warp_options=None, working_dir=None, use_overview_level=0,
+        gdal_warp_options=None, working_dir=None, use_overview_level=-1,
         raster_driver_creation_tuple=DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS,
         osr_axis_mapping_strategy=DEFAULT_OSR_AXIS_MAPPING_STRATEGY):
     f"""Resize/resample raster to desired pixel size, bbox and projection.
@@ -2242,10 +2242,15 @@ def warp_raster(
         working_dir (string): if defined uses this directory to make
             temporary working files for calculation. Otherwise uses system's
             temp directory.
-        use_overview_level=0 (int): The overview level to use for warping.
-            A value of ``0`` (the default) indicates that the base raster
-            should be used.
-            # TODO: what about other overview levels?
+        use_overview_level=-1 (int/str): The overview level to use for warping.
+            A value of ``-1`` (the default) indicates that the base raster
+            should be used for the source pixels. A value of ``'AUTO'``
+            will make GDAL select the overview with the resolution that is
+            closest to the target pixel size and warp using that overview's
+            pixel values.  Any other integer indicates that that overview index
+            should be used.  For example, suppose the raster has overviews at
+            levels 2, 4 and 8.  To use level 2, set ``use_overview_level=0``.
+            To use level 8, set ``use_overview_level=2``.
         raster_driver_creation_tuple (tuple): a tuple containing a GDAL driver
             name string as the first element and a GDAL creation options
             tuple/list as the second. Defaults to a GTiff driver tuple

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -121,9 +121,9 @@ for _warp_algo in (_attrname for _attrname in dir(gdalconst)
             # (GDAL < 3.4) Translate shorthand params to name.
             # (GDAL < 3.4) Translate unrecognized (int) codes to name.
             _item = re.sub('^gra_', '', _warp_algo.lower())
+        _GDAL_WARP_ALGORITHMS.append(_item)
 
 _GDAL_WARP_ALGORITHMS = set(_GDAL_WARP_ALGORITHMS)
-_GDAL_WARP_ALGORITHMS.discard('-r')
 _GDAL_WARP_ALGOS_FOR_HUMAN_EYES = "|".join(_GDAL_WARP_ALGORITHMS)
 LOGGER.debug(
     f'Detected warp algorithms: {", ".join(_GDAL_WARP_ALGOS_FOR_HUMAN_EYES)}')

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2196,7 +2196,7 @@ def warp_raster(
         base_raster_path, target_pixel_size, target_raster_path,
         resample_method, target_bb=None, base_projection_wkt=None,
         target_projection_wkt=None, n_threads=None, vector_mask_options=None,
-        gdal_warp_options=None, working_dir=None,
+        gdal_warp_options=None, working_dir=None, use_overview_level=0,
         raster_driver_creation_tuple=DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS,
         osr_axis_mapping_strategy=DEFAULT_OSR_AXIS_MAPPING_STRATEGY):
     f"""Resize/resample raster to desired pixel size, bbox and projection.
@@ -2380,6 +2380,7 @@ def warp_raster(
         dstSRS=target_projection_wkt,
         multithread=True if warp_options else False,
         warpOptions=warp_options,
+        overviewLevel=use_overview_level,
         creationOptions=raster_creation_options,
         callback=reproject_callback,
         callback_data=[target_raster_path])

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -31,10 +31,10 @@ from osgeo import ogr
 from osgeo import osr
 
 from . import geoprocessing_core
-from .geoprocessing_core import DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS
 from .geoprocessing_core import DEFAULT_CREATION_OPTIONS
-from .geoprocessing_core import INT8_CREATION_OPTIONS
+from .geoprocessing_core import DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS
 from .geoprocessing_core import DEFAULT_OSR_AXIS_MAPPING_STRATEGY
+from .geoprocessing_core import INT8_CREATION_OPTIONS
 
 # This is used to efficiently pass data to the raster stats worker if available
 if sys.version_info >= (3, 8):
@@ -118,11 +118,12 @@ for _warp_algo in (_attrname for _attrname in dir(gdalconst)
     # options to their string names (but compatibility is limited in different
     # GDAL versions, see notes above)
     warp_opts = gdal.WarpOptions(
-        options=_options,  # Add rendered flags to this list.
+        options=_options,  # SIDE EFFECT: Adds flags to this list.
         resampleAlg=getattr(gdalconst, _warp_algo),  # use GRA_* name.
         overviewLevel=None)  # Don't add overview parameters.
     gdal.PopErrorHandler()
 
+    # _options is populated during the WarpOptions call above.
     for _item in _options:
         is_int = False
         try:

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2242,6 +2242,10 @@ def warp_raster(
         working_dir (string): if defined uses this directory to make
             temporary working files for calculation. Otherwise uses system's
             temp directory.
+        use_overview_level=0 (int): The overview level to use for warping.
+            A value of ``0`` (the default) indicates that the base raster
+            should be used.
+            # TODO: what about other overview levels?
         raster_driver_creation_tuple (tuple): a tuple containing a GDAL driver
             name string as the first element and a GDAL creation options
             tuple/list as the second. Defaults to a GTiff driver tuple

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -1691,6 +1691,54 @@ class TestGeoprocessing(unittest.TestCase):
                 pygeoprocessing.raster_to_numpy_array(
                     target_raster_path)).all())
 
+    def test_warp_raster_overview_level(self):
+        """PGP.geoprocessing: warp raster overview test."""
+        # This array is big enough that build_overviews will render several
+        # overview levels.
+        pixel_a_matrix = numpy.array([
+            [1, 2, 3, 4],
+            [1, 2, 3, 4],
+            [1, 2, 3, 4],
+            [1, 2, 3, 4],
+        ], dtype=numpy.float32)
+
+        # Using overview level 0 (the base raster), we should have the same
+        # output when we warp the array that has and does not have overviews
+        # present.
+        target_nodata = -1
+        base_a_path = os.path.join(self.workspace_dir, 'base_a.tif')
+        _array_to_raster(
+            pixel_a_matrix, target_nodata, base_a_path)
+        base_a_raster_info = pygeoprocessing.get_raster_info(base_a_path)
+        warped_a_path = os.path.join(self.workspace_dir, 'warped_a.tif')
+        pygeoprocessing.warp_raster(
+            base_a_path, base_a_raster_info['pixel_size'], warped_a_path,
+            'bilinear', use_overview_level=-1)
+
+        base_b_path = os.path.join(self.workspace_dir, 'base_b.tif')
+        _array_to_raster(
+            pixel_a_matrix, target_nodata, base_b_path)
+        warped_b_path = os.path.join(self.workspace_dir, 'warped_b.tif')
+        pygeoprocessing.build_overviews(
+            base_b_path, levels=[2, 4], resample_method='bilinear')
+        pygeoprocessing.warp_raster(
+            base_b_path, base_a_raster_info['pixel_size'], warped_b_path,
+            'bilinear', use_overview_level=-1)
+
+        warped_a_array = pygeoprocessing.raster_to_numpy_array(warped_a_path)
+        warped_b_array = pygeoprocessing.raster_to_numpy_array(warped_b_path)
+        numpy.testing.assert_allclose(warped_a_array, warped_b_array)
+
+        # Force warping using a higher overview level.
+        # Overview level 2 really means the 2nd overview in the stack, which is
+        # where 4 pixels are aggregated into 1 value.
+        target_raster_path = os.path.join(self.workspace_dir, 'target_c.tif')
+        pygeoprocessing.warp_raster(
+            base_b_path, base_a_raster_info['pixel_size'], target_raster_path,
+            'bilinear', n_threads=1, use_overview_level=1)
+        array = pygeoprocessing.raster_to_numpy_array(target_raster_path)
+        numpy.testing.assert_allclose(array, 2.5)
+
     def test_warp_raster_invalid_resample_alg(self):
         """PGP.geoprocessing: error on invalid resample algorithm."""
         pixel_a_matrix = numpy.ones((5, 5), numpy.int16)


### PR DESCRIPTION
`gdal.Warp` has a parameter that allows the user to specify the over view level to use when warping pixels.  The default behavior, from GDAL's perspective, is that if overviews are present, it will select the overview that is closest to the target resolution and then warp those pixels into the target raster.  This would save computational time.  Unfortunately, this also can lead to unexpected results in some cases, as we found in the NCI water quality pipeline.

The solution here is to expose the overview level to use as a parameter to `pygeoprocessing.warp_raster`, which defaults to `-1`, indicating the base raster.

Fixes #326 