### PR TITLE
Handling complex stddev values from `raster_calculator`'s stats worker

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -37,6 +37,10 @@ Unreleased Changes
   where the function would raise an Exception when the target raster path was
   provided as a filename only, not within a directory, even though the parent
   directory could be inferred. https://github.com/natcap/pygeoprocessing/issues/313
+* Fixing a bug where the statistics worker in
+  ``pygeoprocessing.raster_calculator`` may return a complex value. This is
+  only an issue when pygeoprocessing is compiled against Cython 3.0.0 and
+  later. https://github.com/natcap/pygeoprocessing/issues/342
 
 2.4.0 (2023-03-03)
 ------------------

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -610,6 +610,11 @@ def raster_calculator(
             payload = stats_worker_queue.get(True, max_timeout)
             if payload is not None:
                 target_min, target_max, target_mean, target_stddev = payload
+                # In Cython 3.0.0+, taking a square root may return a complex.
+                # Using only the real component of the complex value mimics the
+                # C behavior that we expect from our stats worker.
+                if isinstance(target_stddev, complex):
+                    target_stddev = target_stddev.real
                 target_band.SetStatistics(
                     float(target_min), float(target_max), float(target_mean),
                     float(target_stddev))


### PR DESCRIPTION
I wasn't sure how to test this effectively since this is an environment issue and pygeoprocessing currently requires Cython < 3.0.

Fixes #342