### PR TITLE
Improve `int` memory usage throughout routing

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,16 @@
 Release History
 ===============
 
+Unreleased Changes
+------------------
+* Fixed an issue where MFD flow direction was producing many nodata holes given
+  a large-enough DEM.  These nodata holes would then propagate to flow
+  accumulation and stream extraction, producing very disjointed stream
+  networks. https://github.com/natcap/pygeoprocessing/issues/350
+* Improved progress logging in MFD flow direction, MFD flow accumulation, MFD
+  stream extraction to prevent integer overflows in percentages and improve
+  the readability of log messages. https://github.com/natcap/pygeoprocessing/issues/246
+
 2.4.1 (2023-09-05)
 ------------------
 * The ``pygeoprocessing`` package metadata has been updated to use


### PR DESCRIPTION
This PR addresses two issues in `routing.pyx`:

1. Fixes #246 : progress logging throughout `routing.py` is improved.  Specifically:
   * The overflow issue has been addressed (progress logging should work on rasters with up to 2^64 pixels now)
   * All progress logging now states what operation is running. No more plain `40.2% complete` statements.
2. Fixes #350 : I believe the key fix was that the plateau distance nodata value was suffering an integer overflow due to being the product of two signed integers, which meant the compiler most likely inferred that the result should also be a signed integer.  Forcing this into an unsigned long (which will then be cast to a `double` by GDAL when written out to a Float64 raster) resolves the issue.

I ended up adjusting most integers that represent unsigned integer data to unsigned integers to increase the range of available values possible before we run into this issue again.  In most cases, `unsigned int` is plenty large for our purposes.  If we had a DEM of 2^32 pixels wide at a 1m resolution, that would be 10 times larger than the circumference of the earth!