### PR TITLE
Bugfix for nodata handling in `extract_strahler_streams_d8`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,10 @@ Unreleased Changes
   environment variables), the GDAL cache max is checked against the amount of
   memory available on the compute node.  If GDAL may exceed the available slurm
   memory, a warning is issued or logged. https://github.com/natcap/pygeoprocessing/issues/361
+* Fixed an issue in ``extract_strahler_streams_d8`` where a nodata pixel
+  could be mistakenly treated as a stream seed point, ultimately creating
+  a stream feature with no geometry. 
+  https://github.com/natcap/pygeoprocessing/issues/361
 
 2.4.2 (2023-10-24)
 ------------------

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -4877,7 +4877,7 @@ cdef _calculate_stream_geometry(
 def _delete_feature(
         stream_feature, stream_layer, upstream_to_downstream_id,
         downstream_to_upstream_ids):
-    """Helper for Mahler extraction to delete all references to a stream.
+    """Helper for Strahler extraction to delete all references to a stream.
 
     Args:
         stream_feature (ogr.Feature): feature to delete

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -148,7 +148,7 @@ cdef struct MFDFlowPixelType:
     double sum_of_weights
 
 # used when constructing geometric streams, the x/y coordinates represent
-# a seed point to walk upstream from, the upstream_flow_dir indicates the
+# a seed point to walk upstream from, the upstream_d8_dir indicates the
 # d8 flow direction to walk and the source_id indicates the source stream it
 # spawned from
 cdef struct StreamConnectivityPoint:
@@ -3197,8 +3197,6 @@ def extract_strahler_streams_d8(
             from the upstream to downstream component of this stream
             segment.
         * "outlet" (int): 1 if this segment is an outlet, 0 if not.
-        * "river_id": unique ID among all stream segments which are
-            hydrologically connected.
         * "us_fa" (int): flow accumulation value at the upstream end of
             the stream segment.
         * "ds_fa" (int): flow accumulation value at the downstream end of

--- a/src/pygeoprocessing/routing/routing.pyx
+++ b/src/pygeoprocessing/routing/routing.pyx
@@ -3359,13 +3359,13 @@ def extract_strahler_streams_d8(
                     x_l, y_l)
                 if (local_flow_accum < min_flow_accum_threshold or
                         _is_close(local_flow_accum,
-                            flow_accum_nodata, 1e-8, 1e-5)):
+                                  flow_accum_nodata, 1e-8, 1e-5)):
                     continue
                 # check to see if it's a drain
                 d_n = <int>flow_dir_managed_raster.get(x_l, y_l)
                 x_n = x_l + D8_XOFFSET[d_n]
                 y_n = y_l + D8_YOFFSET[d_n]
-                if (x_n < 0 or y_n < 0 or x_n >= n_cols or y_n >= n_cols or
+                if (x_n < 0 or y_n < 0 or x_n >= n_cols or y_n >= n_rows or
                         <int>flow_dir_managed_raster.get(
                             x_n, y_n) == flow_nodata):
                     is_drain = 1

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -23,7 +23,7 @@ class TestRouting(unittest.TestCase):
 
     def tearDown(self):
         """Clean up remaining files."""
-        # shutil.rmtree(self.workspace_dir)
+        shutil.rmtree(self.workspace_dir)
 
     def test_pit_filling(self):
         """PGP.routing: test pitfilling."""

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1135,7 +1135,7 @@ class TestRouting(unittest.TestCase):
         """PGP.routing: test Strahler stream and subwatershed creation."""
         # make a long canyon herringbone style DEM that will have a main
         # central river and single pixel tributaries every other pixel to
-        # the west and east as one steps south the canyon
+        # the west and east as one steps south through the canyon
         n = 53
         dem_array = numpy.zeros((n, 3))
         dem_array[0, 1] = -0.5


### PR DESCRIPTION
Fixes #363 

We needed a `double` instead of a `long` to accommodate the nodata value of a flow_accumulation raster. And we needed to check for the presence of that nodata value.

I modified some test data to raise the exception seen in #363 before applying this fix. But it's such a special construction of the DEM that it makes the expected values under test (number of stream features, number of watersheds, etc) much harder to reason about. After doing all that, I think it might actually be better to leave the test as it was, instead of manipulating it to cover this edge case. What do you think?