### PR TITLE
`get_gis_type` remote file access

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,10 +3,14 @@ Release History
 
 Unreleased Changes
 ------------------
+* ``get_gis_type`` can accept a path to a remote file, allowing the GDAL driver
+  to open it if the driver supports the protocol.
+  https://github.com/natcap/pygeoprocessing/issues/375
 * If running on a SLURM system (identified by the presence of ``SLURM*``
   environment variables), the GDAL cache max is checked against the amount of
   memory available on the compute node.  If GDAL may exceed the available slurm
-  memory, a warning is issued or logged. https://github.com/natcap/pygeoprocessing/issues/361
+  memory, a warning is issued or logged.
+  https://github.com/natcap/pygeoprocessing/issues/361
 * Fixed an issue in ``extract_strahler_streams_d8`` where a nodata pixel
   could be mistakenly treated as a stream seed point, ultimately creating
   a stream feature with no geometry.

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -3895,8 +3895,6 @@ def get_gis_type(path):
         ``pygeoprocessing.RASTER_TYPE``, or ``pygeoprocessing.VECTOR_TYPE``.
 
     """
-    if not os.path.exists(path):
-        raise ValueError(f"{path} does not exist.")
     from pygeoprocessing import UNKNOWN_TYPE
     gis_type = UNKNOWN_TYPE
     gis_raster = gdal.OpenEx(path, gdal.OF_RASTER)

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -3882,7 +3882,7 @@ def get_gis_type(path):
     """Calculate the GIS type of the file located at ``path``.
 
     Args:
-        path (str): path to a file on disk.
+        path (str): path to a file on disk or network.
 
     Raises:
         ValueError

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -4855,7 +4855,7 @@ class TestGeoprocessing(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             pygeoprocessing.get_gis_type('totally_fake_file')
         actual_message = str(cm.exception)
-        self.assertTrue('does not exist' in actual_message, actual_message)
+        self.assertTrue('Could not open' in actual_message, actual_message)
 
     def test_get_raster_info_type(self):
         """PGP: test get_raster_info's type."""


### PR DESCRIPTION
Fixes #375 

The cost of this change is a slightly less informative error message when a file does not exist. Instead of telling the user,
`"{path} does not exist"`, we tell them `"{path} could not be opened as a GDAL raster or vector"`.

That's somewhat unsatisfying, but as it is the much more commonly used `get_raster_info` and `get_vector_info` already give the `"Could not open as a gdal.OF_RASTER"` message when the file does not exist.