### PR TITLE
Add python 3.12 to our wheel build action

### DIFF
--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -8,7 +8,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [windows-latest, macos-latest]
-                python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+                python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
                 python-arch: [x64]
 
         steps:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 Release History
 ===============
 
+Unreleased Changes
+------------------
+* Wheels for python 3.12 are now built during our github actions runs.
+  https://github.com/natcap/pygeoprocessing/issues/381
+
 2.4.3 (2024-03-06)
 ------------------
 * ``get_gis_type`` can accept a path to a remote file, allowing the GDAL driver


### PR DESCRIPTION
Minor fix that came up when going through the release.  This is not required for the 2.4.3 release, but it will be useful for future releases.