### PR TITLE
Moving wheel build into today's release

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,13 +1,11 @@
 Release History
 ===============
 
-Unreleased Changes
-------------------
-* Wheels for python 3.12 are now built during our github actions runs.
-  https://github.com/natcap/pygeoprocessing/issues/381
 
 2.4.3 (2024-03-06)
 ------------------
+* Wheels for python 3.12 are now built during our github actions runs.
+  https://github.com/natcap/pygeoprocessing/issues/381
 * ``get_gis_type`` can accept a path to a remote file, allowing the GDAL driver
   to open it if the driver supports the protocol.
   https://github.com/natcap/pygeoprocessing/issues/375


### PR DESCRIPTION
For convenience, updating the build automation as a part of the release.  The tag will be moved to the merge commit once this goes through.