### PR TITLE
Updating `actions/setup-python` version to remove nodejs version warnings

### DIFF
--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -21,7 +21,7 @@ jobs:
               run: git fetch origin +refs/tags/*:refs/tags/*
 
             - name: Set up python ${{ matrix.python-version }} ${{ matrix.python-arch }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
                   architecture: ${{ matrix.python-arch }}
@@ -50,7 +50,7 @@ jobs:
               run: git fetch origin +refs/tags/*:refs/tags/*
 
             - name: Set up python
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: 3.7
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 Release History
 ===============
 
+Unreleased Changes
+------------------
+* Our github actions for building python distributions now use
+  `actions/setup-python@v5`, which uses node 20.
+  https://github.com/natcap/pygeoprocessing/issues/384
 
 2.4.3 (2024-03-06)
 ------------------


### PR DESCRIPTION
Just a simple update to fix a pending nodejs version deprecation.

Fixes #384 