### PR TITLE
proposal/bugfix: Remove checks for gdal resampling algorithm values

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,10 @@ Unreleased Changes
 * Our github actions for building python distributions now use
   `actions/setup-python@v5`, which uses node 20.
   https://github.com/natcap/pygeoprocessing/issues/384
+* ``warp_raster`` and ``build_overviews`` no longer raise ``ValueError``s if
+  called with an invalid resampling algorithm. We now fall back to the
+  underlying GDAL functions' error messages.
+  https://github.com/natcap/pygeoprocessing/issues/387
 
 2.4.3 (2024-03-06)
 ------------------

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2435,7 +2435,8 @@ def warp_raster(
             the x and y pixel size in projected units.
         target_raster_path (string): the location of the resized and
             resampled raster.
-        resample_method (string): the resampling technique, one of,
+        resample_method (string): the resampling algorithm. Must be a valid
+            resampling algorithm for `gdal.WarpRaster`, one of:
             'rms | mode | sum | q1 | near | q3 | average | cubicspline |
             bilinear | max | med | min | cubic | lanczos'
         target_bb (sequence): if None, target bounding box is the same as the
@@ -4579,7 +4580,8 @@ def build_overviews(
             overviews. In GeoTiffs, this builds internal overviews when
             ``internal=True``, and external overviews when ``internal=False``.
         resample_method='near' (str): The resample method to use when
-            building overviews.  Must be one of,
+            building overviews.  Must be a valid resampling method for
+            ``gdal.GDALDataset.BuildOverviews``, one of
             'rms | mode | sum | q1 | near | q3 | average | cubicspline |
             bilinear | max | med | min | cubic | lanczos'.
         overwrite=False (bool): Whether to overwrite existing overviews, if
@@ -4603,7 +4605,6 @@ def build_overviews(
     Returns:
         ``None``
     """
-    gdal.UseExceptions()
     def overviews_progress(*args, **kwargs):
         pct_complete, name, other = args
         percent = round(pct_complete * 100, 2)

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -1753,12 +1753,12 @@ class TestGeoprocessing(unittest.TestCase):
         target_raster_path = os.path.join(self.workspace_dir, 'target_a.tif')
         base_a_raster_info = pygeoprocessing.get_raster_info(base_a_path)
 
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(TypeError) as context:
             pygeoprocessing.warp_raster(
                 base_a_path, base_a_raster_info['pixel_size'],
                 target_raster_path, 'not_an_algorithm', n_threads=1)
 
-        self.assertIn('Invalid resample method', str(context.exception))
+        self.assertIn('GDALWarpAppOptions', str(context.exception))
 
     def test_warp_raster_unusual_pixel_size(self):
         """PGP.geoprocessing: warp on unusual pixel types and sizes."""
@@ -5553,12 +5553,11 @@ class TestGeoprocessing(unittest.TestCase):
         pygeoprocessing.build_overviews(raster_path, overwrite=True)
 
         # Check that we can catch invalid resample methods
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(RuntimeError) as cm:
             pygeoprocessing.build_overviews(
                 raster_path, overwrite=True,
                 resample_method='invalid choice')
-        self.assertIn('Invalid overview resample method: "invalid choice"',
-                      str(cm.exception))
+        self.assertIn('Building overviews failed', str(cm.exception))
 
     def test_get_raster_info_overviews(self):
         """PGP: raster info about overviews."""


### PR DESCRIPTION
Fixes #387 

This was pretty simple so I went ahead with it, but happy to consider alternatives too!

We were relying on a gdal bug to build a list of human-readable names for resampling algorithms. In gdal 3.8.5, this no longer works. We could implement a different way to get the names, but I propose that we remove the list entirely.

The lists in question (`_GDAL_WARP_ALGORITHMS` and `_GDAL_WARP_ALGOS_FOR_HUMAN_EYES`) are used in `warp_raster` and `build_overviews`. They're only used to check that the provided resampling algorithm is a valid option, and raise a helpful error message if not. I think we can do away with that because GDAL raises its own (slightly less helpful) error message if given an invalid algorithm name:

`gdal.WarpRaster` raises a `TypeError: in method 'wrapper_GDALWarpDestName', argument 4 of type 'GDALWarpAppOptions *'` and prints out `ERROR 5: Unknown resampling method: <resampling method>.` With `gdal.UseExceptions()`, you get a nicer `RuntimeError: Unknown resampling method: <resampling method>.`

`gdal.BuildOverviews` raises a `RuntimeError: Building overviews failed or was interrupted for <raster path>.` and prints out `ERROR 1: GDALGetResampleFunction: Unsupported resampling method "<resampling_method>".` With `gdal.UseExceptions()`, you get `RuntimeError: GDALGetResampleFunction: Unsupported resampling method "<resampling method>"`.

These error messages aren't quite as nice as what `pygeoprocessing` had, but they're adequate to identify the issue. Since we pass the resample method argument directly to the underlying gdal function, I think it makes sense to let GDAL handle it.

A couple of behavior changes:
- The `gdal.WarpRaster` resample algorithm argument can be a `gdal.GRA_*` constant as well as a string name. By removing the pygeoprocessing check, we can accept `gdal.GRA_*` constants too.
- `gdal.WarpRaster` and `gdal.BuildOverviews` use the nearest neighbor algorithm if the resampling argument _starts with_ 'near'. So 'near', 'nearest', 'nearest_neighbor', and 'near_foo' all work.