### PR TITLE
replace gdal exceptions decorator with context manager

### DIFF
--- a/src/pygeoprocessing/slurm_utils.py
+++ b/src/pygeoprocessing/slurm_utils.py
@@ -4,12 +4,11 @@ import warnings
 
 from osgeo import gdal
 
-from .geoprocessing_core import gdal_use_exceptions
+from .geoprocessing_core import GDALUseExceptions
 
 LOGGER = logging.getLogger(__name__)
 
 
-@gdal_use_exceptions
 def log_warning_if_gdal_will_exhaust_slurm_memory():
     """Warn if GDAL's cache max size exceeds SLURM's allocated memory.
 
@@ -29,7 +28,8 @@ def log_warning_if_gdal_will_exhaust_slurm_memory():
     is used directly.
     """
     if {'SLURM_MEM_PER_NODE'}.issubset(set(os.environ.keys())):
-        gdal_cache_size = gdal.GetCacheMax()
+        with GDALUseExceptions():
+            gdal_cache_size = gdal.GetCacheMax()
         if gdal_cache_size < 100000:
             # If the cache size is 100,000 or greater, it's assumed to be in
             # bytes.  Otherwise, units are interpreted as megabytes.


### PR DESCRIPTION
I noticed that a bunch of functions were missing from the pygeoprocessing API docs, and it's because of the decorator I introduced in #392. The functions returned from the decorator don't have the docstring of the original, so no docs were generated. 

This was the last straw - since I ran into other issues with the decorator before with multiprocessing and pickling, I decided to remove it and use the reliable context manager everywhere. The extra indentation is annoying in a few places, but this should be a temporary situation until we adopt GDAL 4.