### PR TITLE
Fix compilation/testing issues against numpy 2.0

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -51,7 +51,6 @@ jobs:
           condarc: |
               channels:
                 - conda-forge
-          # temporarily capping numpy<2 until we figure out build issues with gdal>=3.8
           create-args: >-
               python=${{ matrix.python-version }}
               gdal=${{ matrix.gdal }}
@@ -59,7 +58,7 @@ jobs:
               python-build
               flake8
               pytest
-              numpy<2
+              numpy
           environment-name: pyenv
 
       - name: Lint with flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,9 @@ dynamic = ["version", "dependencies", "optional-dependencies", "readme"]
 # that we can provide a much easier build experience so long as GDAL is
 # available at runtime.
 requires = [
-    'setuptools', 'wheel', 'setuptools_scm', 'cython>=3.0.0', 'numpy>=2'
+    'setuptools', 'wheel', 'setuptools_scm', 'cython>=3.0.0',
+    'oldest-supported-numpy; python_version<="3.8"',
+    'numpy>=2; python_version>="3.9"',  # Numpy 2 only available for 3.9+
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dynamic = ["version", "dependencies", "optional-dependencies", "readme"]
 # that we can provide a much easier build experience so long as GDAL is
 # available at runtime.
 requires = [
-    'setuptools', 'wheel', 'setuptools_scm', 'cython>=3.0.0', 'oldest-supported-numpy'
+    'setuptools', 'wheel', 'setuptools_scm', 'cython>=3.0.0', 'numpy>=2'
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
This PR fixes an issue with our build dependencies.  We used to have to use `oldest-supported-numpy` when building to ensure compatibility with older versions of numpy.  It now appears that building against `numpy>=2` is sufficient for allowing pygeoprocessing to run against earlier versions of numpy.

The only catch appears to be that numpy 2 was only released for python>=3.9, so we are still building against `oldest-supported-numpy` for python 3.8 builds.