### PR TITLE
use functools.wraps with gdal exceptions decorator

### DIFF
--- a/src/pygeoprocessing/geoprocessing_core.pyx
+++ b/src/pygeoprocessing/geoprocessing_core.pyx
@@ -1,3 +1,4 @@
+import functools
 import logging
 import multiprocessing
 import os
@@ -71,6 +72,7 @@ def gdal_use_exceptions(func):
     Returns:
         Wrapper function that calls ``func`` with GDAL exceptions enabled
     """
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         with GDALUseExceptions():
             return func(*args, **kwargs)


### PR DESCRIPTION
Thanks for the suggestion @phargogh! That was an easy fix. I confirmed that the wrapped functions now have docstrings and can be pickled.

