### PR TITLE
Remove the numpy version cap

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,10 @@
 Release History
 ===============
 
-.. Unreleased Changes
+Unreleased Changes
+------------------
+* Removing the ``numpy<2`` constraint for requirements.txt that should have
+  been included in the 2.4.5 release. https://github.com/natcap/pygeoprocessing/issues/396
 
 2.4.5 (2024-10-08)
 ------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # This file records the packages and requirements needed in order for
 # pygeoprocessing to work as expected.
 GDAL>=3.0.4
-numpy>=1.10.1,<2.0
+numpy>=1.10.1
 Rtree>=0.8.3
 scipy>=0.14.1,!=0.19.1
 Shapely>=1.6.4


### PR DESCRIPTION
This should have been included in the 2.4.5 release (#404 ), but I forgot about it.  Nothing should break with the 2.4.5 release, it's just that the next release will allow numpy 2 to be installed at pip-install time.

Fixes #403 