### PR TITLE
Improve exception on `convolve_2d` worker timeout

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,11 @@ Release History
 ------------------
 * Updating for numpy 2.0 API changes.  Pygeoprocessing is now compatible with
   numpy 2.0 and later.  https://github.com/natcap/pygeoprocessing/issues/396
+* Fixed an issue in ``convolve_2d`` where a long-running convolution would
+  raise a cryptic exception involving ``queue.Empty``.  This will instead now
+  raise ``RuntimeError`` with a more helpful exception message.  We also fixed
+  an issue where the ``max_timeout`` parameter of ``convolve_2d`` was unused,
+  so it is now used correctly. https://github.com/natcap/pygeoprocessing/issues/360
 
 2.4.4 (2024-05-21)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,16 +5,16 @@ Unreleased Changes
 ------------------
 * Removing the ``numpy<2`` constraint for requirements.txt that should have
   been included in the 2.4.5 release. https://github.com/natcap/pygeoprocessing/issues/396
-
-2.4.5 (2024-10-08)
-------------------
-* Updating for numpy 2.0 API changes.  Pygeoprocessing is now compatible with
-  numpy 2.0 and later.  https://github.com/natcap/pygeoprocessing/issues/396
 * Fixed an issue in ``convolve_2d`` where a long-running convolution would
   raise a cryptic exception involving ``queue.Empty``.  This will instead now
   raise ``RuntimeError`` with a more helpful exception message.  We also fixed
   an issue where the ``max_timeout`` parameter of ``convolve_2d`` was unused,
   so it is now used correctly. https://github.com/natcap/pygeoprocessing/issues/360
+
+2.4.5 (2024-10-08)
+------------------
+* Updating for numpy 2.0 API changes.  Pygeoprocessing is now compatible with
+  numpy 2.0 and later.  https://github.com/natcap/pygeoprocessing/issues/396
 
 2.4.4 (2024-05-21)
 ------------------

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -3299,6 +3299,13 @@ def convolve_2d(
                 worker.join(max_timeout)
                 break
         except queue.Empty:
+            # Shut down the worker thread.
+            # The work queue only has 10 items in it at a time, so it's pretty
+            # likely that we can preemptively shut it down by adding a ``None``
+            # here and then have the queue not take too much longer to quit.
+            work_queue.put(None)
+
+            # Close thread-local raster objects
             signal_raster = signal_band = None
             target_raster = target_band = None
             mask_raster = mask_band = None

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -3290,6 +3290,9 @@ def convolve_2d(
         try:
             write_payload = write_queue.get(timeout=max_timeout)
         except queue.Empty:
+            signal_raster = signal_band = None
+            target_raster = target_band = None
+            mask_raster = mask_band = None
             raise RuntimeError(
                 f"The convolution worker timed out after {max_timeout} "
                 "seconds. Either the timeout is too low for the "

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -3437,6 +3437,10 @@ class TestGeoprocessing(unittest.TestCase):
                 (signal_path, 1), (kernel_path, 1), target_path,
                 max_timeout=0.5)
 
+        # Wait for the worker thread to catch up
+        # Hacky, but should be enough to avoid test failures.
+        time.sleep(2)
+
     def test_calculate_slope(self):
         """PGP.geoprocessing: test calculate slope."""
         n_pixels = 9

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -4048,7 +4048,7 @@ class TestGeoprocessing(unittest.TestCase):
             not_a_raster_file.write("this is not a raster.\n")
         with self.assertRaises(RuntimeError) as cm:
             pygeoprocessing.get_raster_info(not_a_raster_path)
-        self.assertIn('not recognized as a supported file format', str(cm.exception))
+        self.assertIn('supported file format', str(cm.exception))
 
     def test_get_vector_info_error_handling(self):
         """PGP: test that bad data raise good errors in get_vector_info."""
@@ -4065,7 +4065,7 @@ class TestGeoprocessing(unittest.TestCase):
             not_a_vector_file.write("this is not a vector.\n")
         with self.assertRaises(RuntimeError) as cm:
             pygeoprocessing.get_vector_info(not_a_vector_path)
-        self.assertIn('not recognized as a supported file format', str(cm.exception))
+        self.assertIn('supported file format', str(cm.exception))
 
     def test_merge_bounding_box_list(self):
         """PGP: test merge_bounding_box_list."""

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -3439,7 +3439,7 @@ class TestGeoprocessing(unittest.TestCase):
 
         # Wait for the worker thread to catch up
         # Hacky, but should be enough to avoid test failures.
-        time.sleep(2)
+        time.sleep(0.5)
 
     def test_calculate_slope(self):
         """PGP.geoprocessing: test calculate slope."""

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -32,10 +32,10 @@ from osgeo import osr
 from pygeoprocessing.geoprocessing_core import DEFAULT_CREATION_OPTIONS
 from pygeoprocessing.geoprocessing_core import \
     DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS
+from pygeoprocessing.geoprocessing_core import gdal_use_exceptions
 from pygeoprocessing.geoprocessing_core import INT8_CREATION_OPTIONS
 from pygeoprocessing.geoprocessing_core import \
     INT8_GTIFF_CREATION_TUPLE_OPTIONS
-from pygeoprocessing.geoprocessing_core import gdal_use_exceptions
 
 _DEFAULT_ORIGIN = (444720, 3751320)
 _DEFAULT_PIXEL_SIZE = (30, -30)
@@ -3415,6 +3415,27 @@ class TestGeoprocessing(unittest.TestCase):
         self.assertTrue(
             numpy.isclose(signal_nodata_array, signal_nodata_none_array).all(),
             'signal with nodata should be the same as signal with none')
+
+    def test_convolve_2d_error_on_worker_timeout(self):
+        """PGP.geoprocessing: test convolve 2d error when worker times out."""
+        n_pixels = 10000
+        n_kernel_pixels = 17500
+        signal_array = numpy.ones((n_pixels, n_pixels), numpy.float32)
+        test_value = 0.5
+        signal_array[:] = test_value
+        target_nodata = -1
+        signal_path = os.path.join(self.workspace_dir, 'signal.tif')
+        _array_to_raster(signal_array, target_nodata, signal_path)
+        kernel_path = os.path.join(self.workspace_dir, 'kernel.tif')
+        kernel_array = numpy.zeros(
+            (n_kernel_pixels, n_kernel_pixels), numpy.float32)
+        kernel_array[int(n_kernel_pixels/2), int(n_kernel_pixels/2)] = 1
+        _array_to_raster(kernel_array, target_nodata, kernel_path)
+        target_path = os.path.join(self.workspace_dir, 'target.tif')
+        with self.assertRaises(RuntimeError):
+            pygeoprocessing.convolve_2d(
+                (signal_path, 1), (kernel_path, 1), target_path,
+                max_timeout=0.5)
 
     def test_calculate_slope(self):
         """PGP.geoprocessing: test calculate slope."""


### PR DESCRIPTION
This PR makes 2 concrete improvements to `convolve_2d`:

1. Instead of raising `queue.Empty` on timeout, `RuntimeError` with a more helpful message is raised
2. We were not using the function signature's `max_timeout` parameter, so we are now using it.

Also, I shortened the text we're asserting in a couple other tests because recent versions of GDAL made some adjustments to the text of their exceptions.  Shortening the string we're asserting allows us to have the test remain valid for all the GDAL versions we're checking.

Fixes #360 