### PR TITLE
Handle GDAL exceptions raised in `reproject_vector`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ Unreleased Changes
 ------------------
 * Removing the ``numpy<2`` constraint for requirements.txt that should have
   been included in the 2.4.5 release. https://github.com/natcap/pygeoprocessing/issues/396
+* Handling GDAL-based ``RuntimeError``s raised during ``pygeoprocessing.reproject_vector``.
+  https://github.com/natcap/pygeoprocessing/issues/409
 
 2.4.5 (2024-10-08)
 ------------------


### PR DESCRIPTION
This just adds support for GDAL exceptions to `reproject_vector` while keeping the old error handling around in case gdal's exception functionality isn't enabled.

Fixes #409 