### PR TITLE
Add an LRU Cache to the convolution worker

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ Unreleased Changes
 ------------------
 * Removing the ``numpy<2`` constraint for requirements.txt that should have
   been included in the 2.4.5 release. https://github.com/natcap/pygeoprocessing/issues/396
+* An LRU Cache has been added to ``convolve_2d`` which should reduce runtimes
+  on large rasters by approximately 10%. https://github.com/natcap/pygeoprocessing/issues/373
 
 2.4.5 (2024-10-08)
 ------------------


### PR DESCRIPTION
Reading pixel values during the convolution worker's execution allows us a bit of a speedup.  On a ~3GB signal raster with a 200px-by-200px kernel raster, I'm seeing speedups of about 10%.  There remain interesting opportunities for us to optimize further by more carefully considering spatial locality in scheduling of blocks for the worker.

Fixes #373 