### PR TITLE
test and build against Python 3.13 and GDAL 3.9

### DIFF
--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -8,7 +8,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [windows-latest, macos-latest]
-                python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+                python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
 
         steps:
             - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
             - name: Set up python
               uses: actions/setup-python@v5
               with:
-                  python-version: 3.12
+                  python-version: 3.13
 
             - name: Install dependencies
               run: python -m pip install build

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -23,18 +23,32 @@ jobs:
             python-version: 3.11
           - gdal: "3.2.2"
             python-version: 3.12
+          - gdal: "3.2.2"
+            python-version: 3.13
           - gdal: "3.3.0"
             python-version: 3.10
           - gdal: "3.3.0"
             python-version: 3.11
           - gdal: "3.3.0"
             python-version: 3.12
+          - gdal: "3.3.0"
+            python-version: 3.13
           - gdal: "3.4.3"
             python-version: 3.11
           - gdal: "3.4.3"
             python-version: 3.12
+          - gdal: "3.4.3"
+            python-version: 3.13
           - gdal: "3.5"
             python-version: 3.12
+          - gdal: "3.5"
+            python-version: 3.13
+          - gdal: "3.6"
+            python-version: 3.13
+          - gdal: "3.7"
+            python-version: 3.13
+          - gdal: "3.8"
+            python-version: 3.13
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        gdal: ["3.2.2", "3.3.0", "3.4.3", "3.5", "3.6", "3.7", "3.8"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        gdal: ["3.2.2", "3.3.0", "3.4.3", "3.5", "3.6", "3.7", "3.8", "3.9"]
         os: [ubuntu-latest, windows-latest, macos-latest]
         exclude:
           - gdal: "3.2.2"

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,35 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        gdal: ["3.2.2", "3.3.0", "3.4.3", "3.5", "3.6", "3.7", "3.8", "3.9"]
+        gdal: ["3.6", "3.7", "3.8", "3.9"]
         os: [ubuntu-latest, windows-latest, macos-latest]
         exclude:
-          - gdal: "3.2.2"
-            python-version: 3.10
-          - gdal: "3.2.2"
-            python-version: 3.11
-          - gdal: "3.2.2"
-            python-version: 3.12
-          - gdal: "3.2.2"
-            python-version: 3.13
-          - gdal: "3.3.0"
-            python-version: 3.10
-          - gdal: "3.3.0"
-            python-version: 3.11
-          - gdal: "3.3.0"
-            python-version: 3.12
-          - gdal: "3.3.0"
-            python-version: 3.13
-          - gdal: "3.4.3"
-            python-version: 3.11
-          - gdal: "3.4.3"
-            python-version: 3.12
-          - gdal: "3.4.3"
-            python-version: 3.13
-          - gdal: "3.5"
-            python-version: 3.12
-          - gdal: "3.5"
-            python-version: 3.13
           - gdal: "3.6"
             python-version: 3.13
           - gdal: "3.7"

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,9 @@ Release History
 
 .. Unreleased Changes
 
+* Dropped support for Python 3.8. Added support for Python 3.13 and GDAL 3.9.
+  https://github.com/natcap/pygeoprocessing/issues/415
+
 2.4.6 (2024-10-15)
 ------------------
 * Removing the ``numpy<2`` constraint for requirements.txt that should have

--- a/README.rst
+++ b/README.rst
@@ -54,3 +54,18 @@ API Documentation
 =================
 
 API documentation is available at https://pygeoprocessing.readthedocs.io/en/latest/
+
+Test Matrix Policy
+==================
+
+Python
+------
+We test against all currently supported (security & bugfix) 
+Python versions.
+https://devguide.python.org/versions/  
+
+GDAL
+----
+We test against the latest GDAL release of each minor version starting 
+with the version included in Debian Stable.
+https://packages.debian.org/stable/science/gdal-bin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,11 @@ classifiers = [
     'Operating System :: MacOS :: MacOS X',
     'Operating System :: Microsoft',
     'Operating System :: POSIX',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: Implementation :: CPython',
     'Topic :: Scientific/Engineering :: GIS',
     'License :: OSI Approved :: BSD License'

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -4069,7 +4069,9 @@ class TestGeoprocessing(unittest.TestCase):
             not_a_raster_file.write("this is not a raster.\n")
         with self.assertRaises(RuntimeError) as cm:
             pygeoprocessing.get_raster_info(not_a_raster_path)
-        self.assertIn('not recognized as a supported file format', str(cm.exception))
+        self.assertRegex(
+            str(cm.exception),
+            r'not recognized as [a-z ]* supported file format')
 
     def test_get_vector_info_error_handling(self):
         """PGP: test that bad data raise good errors in get_vector_info."""
@@ -4086,7 +4088,9 @@ class TestGeoprocessing(unittest.TestCase):
             not_a_vector_file.write("this is not a vector.\n")
         with self.assertRaises(RuntimeError) as cm:
             pygeoprocessing.get_vector_info(not_a_vector_path)
-        self.assertIn('not recognized as a supported file format', str(cm.exception))
+        self.assertRegex(
+            str(cm.exception),
+            r'not recognized as [a-z ]* supported file format')
 
     def test_merge_bounding_box_list(self):
         """PGP: test merge_bounding_box_list."""


### PR DESCRIPTION
For the list of test exclusions, the ones I added are the cases where `libmamba` failed to solve for an environment with those combinations. And the ones removed are based on our decision to refer to the Debian Stable package list for the minimum version to test against.

In addition, an exception message appears to have changed slightly in GDAL, so I updated a test.

Fixes #415 