### PR TITLE
Checks for NA key in value map in reclassify raster function

### DIFF
--- a/src/pygeoprocessing/__init__.py
+++ b/src/pygeoprocessing/__init__.py
@@ -40,6 +40,7 @@ from .geoprocessing import raster_reduce
 from .geoprocessing import raster_to_numpy_array
 from .geoprocessing import rasterize
 from .geoprocessing import ReclassificationMissingValuesError
+from .geoprocessing import InvalidKeyError
 from .geoprocessing import reclassify_raster
 from .geoprocessing import reproject_vector
 from .geoprocessing import shapely_geometry_to_vector

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2352,6 +2352,9 @@ def reclassify_raster(
             if ``values_required`` is ``True``
             and a pixel value from ``base_raster_path_band`` is not a key in
             ``value_map``.
+        InvalidKeyError
+            if there is an "empty" or invalid key in ``value_map``, such as 
+            `NA` or other values that represent missing data.
 
     """
     if len(value_map) == 0:


### PR DESCRIPTION
## Description
Raises new custom InvalidKeyError if there is an NA or other missing value key in the value_map dictionary in the raster reclassification function. 