### PR TITLE
Adding type checking for base, target path inputs to `warp_raster`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,9 @@ Release History
   https://github.com/natcap/pygeoprocessing/issues/415
 * Added validation to ``reclassify_raster`` to raise a ``TypeError`` with a
   descriptive message if ``value_map`` contains non-numeric keys.
+* If either ``base_raster_path`` or ``target_raster_path`` are not strings, a
+  ``ValueError`` is now raised with a more helpful error message.
+  https://github.com/natcap/pygeoprocessing/issues/421
 
 2.4.6 (2024-10-15)
 ------------------

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2507,8 +2507,14 @@ def warp_raster(
             if ``mask_options`` is not None but the
             ``mask_vector_path`` is undefined or doesn't point to a valid
             file.
-
+        ValueError
+            if either ``base_raster_path`` or ``target_raster_path`` are
+            not strings.
     """
+    for path_key in ['base_raster_path', 'target_raster_path']:
+        if not isinstance(locals()[path_key], str):
+            raise ValueError('%s must be a string', path_key)
+
     _assert_is_valid_pixel_size(target_pixel_size)
 
     base_raster_info = get_raster_info(base_raster_path)

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -196,7 +196,7 @@ class TestGeoprocessing(unittest.TestCase):
         target_path = os.path.join(self.workspace_dir, 'target.tif')
         _array_to_raster(
             pixel_matrix, target_nodata, raster_path)
-        
+
         value_map = {1: 2, None: 3, "s": 4, numpy.nan: 5, numpy.float32(99): 6}
         with self.assertRaises(TypeError) as e:
             pygeoprocessing.reclassify_raster(
@@ -1753,6 +1753,30 @@ class TestGeoprocessing(unittest.TestCase):
                 pygeoprocessing.raster_to_numpy_array(base_a_path),
                 pygeoprocessing.raster_to_numpy_array(
                     target_raster_path)).all())
+
+    def test_warp_raster_invalid_paths(self):
+        """PGP.geoprocessing: error on invalid raster paths."""
+        pixel_a_matrix = numpy.ones((5, 5), numpy.int16)
+        target_nodata = -1
+        base_a_path = os.path.join(self.workspace_dir, 'base_a.tif')
+        _array_to_raster(
+            pixel_a_matrix, target_nodata, base_a_path)
+
+        target_raster_path = os.path.join(self.workspace_dir, 'target_a.tif')
+        base_a_raster_info = pygeoprocessing.get_raster_info(base_a_path)
+
+        for invalid_source_path in [(base_a_path,), (base_a_path, 1)]:
+            with self.assertRaises(ValueError):
+                pygeoprocessing.warp_raster(
+                    invalid_source_path, base_a_raster_info['pixel_size'],
+                    target_raster_path, 'near', n_threads=1)
+
+        for invalid_target_path in [(target_raster_path,),
+                                    (target_raster_path, 1)]:
+            with self.assertRaises(ValueError):
+                pygeoprocessing.warp_raster(
+                    base_a_path, base_a_raster_info['pixel_size'],
+                    invalid_target_path, 'near', n_threads=1)
 
     def test_warp_raster_overview_level(self):
         """PGP.geoprocessing: warp raster overview test."""


### PR DESCRIPTION
This PR is a simple fix to #421, where we'd get to a cryptic GDAL error if the developer accidentally provided a source or target path that wasn't a string.  In my case, I passed a tuple.  Now the function will just raise `ValueError` with a short but hopefully more helpful error message if the path provided is not a string.

Fixes:#421