### PR TITLE
catch a RuntimeError from reproject_vector

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@ Release History
 ===============
 
 .. Unreleased Changes
+* ``reproject_vector`` will skip copying field values from the base layer
+  to the target if doing so would raise a RuntimeError,
+  such as when a string value cannot be represented by UTF-8.
+  https://github.com/natcap/pygeoprocessing/issues/418
 
 2.4.7 (2025-01-23)
 ------------------

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2281,10 +2281,15 @@ def reproject_vector(
                 target_feature.SetField(
                     target_index, base_feature.GetField(base_index))
             except RuntimeError as runtime_error:
-                LOGGER.debug(
-                    f"Skipping copy field value for feature {feature_index}, "
-                    f"field {layer_dfn.GetFieldDefn(base_index).GetName()} "
-                    f"due to: {runtime_error}")
+                try:
+                    target_feature.SetFieldBinary(
+                        target_index,
+                        base_feature.GetFieldAsBinary(base_index))
+                except RuntimeError as runtime_error:
+                    LOGGER.debug(
+                        f"Skipping copy field value for feature {feature_index}, "
+                        f"field {layer_dfn.GetFieldDefn(base_index).GetName()} "
+                        f"due to: {runtime_error}")
 
         target_layer.CreateFeature(target_feature)
         target_feature = None

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2277,8 +2277,14 @@ def reproject_vector(
         # source field
         for target_index, base_index in (
                 target_to_base_field_id_map.items()):
-            target_feature.SetField(
-                target_index, base_feature.GetField(base_index))
+            try:
+                target_feature.SetField(
+                    target_index, base_feature.GetField(base_index))
+            except RuntimeError as runtime_error:
+                LOGGER.debug(
+                    f"Skipping copy field value for feature {feature_index}, "
+                    f"field {layer_dfn.GetFieldDefn(base_index).GetName()} "
+                    f"due to: {runtime_error}")
 
         target_layer.CreateFeature(target_feature)
         target_feature = None

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2180,7 +2180,7 @@ def reproject_vector(
 
     target_sr = osr.SpatialReference(target_projection_wkt)
 
-    # create a new shapefile from the orginal_datasource
+    # create a new vector from the orginal_datasource
     target_driver = ogr.GetDriverByName(driver_name)
     target_vector = target_driver.CreateDataSource(target_path)
 
@@ -2280,7 +2280,7 @@ def reproject_vector(
             try:
                 target_feature.SetField(
                     target_index, base_feature.GetField(base_index))
-            except RuntimeError as runtime_error:
+            except RuntimeError:
                 try:
                     target_feature.SetFieldBinary(
                         target_index,


### PR DESCRIPTION
Fixes #418 

I wasn't sure if/how to synthesize an offending dataset and write a test. I have a shapefile that triggers this `RuntimeError`, but I didn't create it myself.

I think the OGR behavior varies by driver. I tried to write a geojson vector with the same characters as present in my shapefile, but reprojecting that to a shapefile, OGR already handles it by issuing a warning. 