### PR TITLE
Support for multipolygons in `zonal_statistics`

### DIFF
--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1689,6 +1689,9 @@ def zonal_statistics(
         raise RuntimeError(
             f"Could not open layer {aggregate_layer_name} of {aggregate_vector_path}")
 
+    # Check that the vector geometry type is polygon or multipolygon
+    if aggregate_layer.GetGeomType() not in [ogr.wkbPolygon, ogr.wkbMultiPolygon]:
+        raise ValueError('Vector geometry type must be Polygon or MultiPolygon')
 
     # Define the default/empty statistics values
     # These values will be returned for features that have no geometry or
@@ -1712,7 +1715,7 @@ def zonal_statistics(
     target_layer = target_vector.CreateLayer(
         name=target_layer_id,
         srs=aggregate_layer.GetSpatialRef(),
-        geom_type=ogr.wkbPolygon)
+        geom_type=aggregate_layer.GetGeomType())
     fid_field_name = 'original_fid'
     target_layer.CreateField(ogr.FieldDefn(fid_field_name, ogr.OFTInteger))
     valid_fid_set = set()

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1559,7 +1559,7 @@ def zonal_statistics(
         aggregate_layer_name=None, ignore_nodata=True,
         polygons_might_overlap=True, include_value_counts=False,
         working_dir=None):
-    """Collect stats on pixel values which lie within polygons.
+    """Collect stats on pixel values which lie within polygons or multipolygons.
 
     This function summarizes raster statistics including min, max,
     mean, and pixel count over the regions on the raster that are
@@ -1649,6 +1649,10 @@ def zonal_statistics(
         ValueError
             if ``base_raster_path_band`` is incorrectly formatted, or if
             not all of the input raster bands are aligned with each other
+
+        ValueError
+            if ``aggregate_vector_path`` has a geometry type other than
+            Polygon or MultiPolygon
 
         RuntimeError
             if the aggregate vector or layer cannot be opened

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -1333,7 +1333,6 @@ class TestGeoprocessing(unittest.TestCase):
                 'sum': 0.0}}
         self.assertEqual(result, expected_result)
 
-
     def test_zonal_statistics_multipolygon(self):
         """PGP.geoprocessing: test zonal stats function with multipolygons."""
         # create aggregating polygon


### PR DESCRIPTION
Fixes #322 
- Check the input geometry type, and raise an error if it's not Polygon or MultiPolygon
- When creating the temporary vector used in `zonal_statistics`, use the appropriate geometry type according to the input type (Polygon or MultiPolygon) to prevent the warnings seen sometimes in invest.

A PR in invest (natcap/invest#1882) goes along with this, but the order of merging doesn't matter. 