### PR TITLE
Warn about geographic CRS in `raster_band_percentile`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,8 @@ Release History
 ===============
 
 .. Unreleased Changes
+* ``raster_band_percentile`` now logs a warning if the raster isn't projected.
+  https://github.com/natcap/pygeoprocessing/issues/299
 
 2.4.7 (2025-01-23)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,8 @@ Release History
 ===============
 
 .. Unreleased Changes
-* ``raster_band_percentile`` now logs a warning if the raster isn't projected.
+* ``raster_band_percentile`` can now optionally log a warning if the raster
+  has a geographic CRS.
   https://github.com/natcap/pygeoprocessing/issues/299
 
 2.4.7 (2025-01-23)

--- a/src/pygeoprocessing/geoprocessing_core.pyx
+++ b/src/pygeoprocessing/geoprocessing_core.pyx
@@ -708,14 +708,14 @@ def raster_band_percentile(
         will select the next element higher than the percentile cutoff).
 
     """
-    g_raster = gdal.OpenEx(base_raster_path_band[0], gdal.OF_RASTER)
-    srs = g_raster.GetSpatialRef()
+    base_raster = gdal.OpenEx(base_raster_path_band[0], gdal.OF_RASTER)
+    srs = base_raster.GetSpatialRef()
     if srs.IsGeographic():
         LOGGER.warning(
             f'Raster {base_raster_path_band[0]} has a geographic CRS (pixels '
             'do not have equal area). Because `raster_band_percentile` calculates '
             'percentiles of pixel values, percentile results will be skewed.')
-    g_raster = None
+    base_raster = None
 
     numpy_type = pygeoprocessing.get_raster_info(
         base_raster_path_band[0])['numpy_type']

--- a/src/pygeoprocessing/geoprocessing_core.pyx
+++ b/src/pygeoprocessing/geoprocessing_core.pyx
@@ -681,7 +681,7 @@ ctypedef FastFileIterator[double]* FastFileIteratorDoublePtr
 
 def raster_band_percentile(
         base_raster_path_band, working_sort_directory, percentile_list,
-        heap_buffer_size=2**28, ffi_buffer_size=2**10):
+        heap_buffer_size=2**28, ffi_buffer_size=2**10, geographic_crs_warn=False):
     """Calculate percentiles of a raster band based on pixel values.
 
     Parameters:
@@ -700,6 +700,8 @@ def raster_band_percentile(
             disk.
         ffi_buffer_size (int): defines how many elements will be stored per
             heap file buffer for iteration.
+        geographic_crs_warn (boolean): defaults to False. If True, a warning will
+            be issued if the base raster has a geographic CRS.
 
     Returns:
         A list of len(percentile_list) elements long containing the
@@ -708,14 +710,17 @@ def raster_band_percentile(
         will select the next element higher than the percentile cutoff).
 
     """
-    base_raster = gdal.OpenEx(base_raster_path_band[0], gdal.OF_RASTER)
-    srs = base_raster.GetSpatialRef()
-    if srs.IsGeographic():
-        LOGGER.warning(
-            f'Raster {base_raster_path_band[0]} has a geographic CRS (pixels '
-            'do not have equal area). Because `raster_band_percentile` calculates '
-            'percentiles of pixel values, percentile results will be skewed.')
-    base_raster = None
+    if geographic_crs_warn:
+        try:
+            base_raster = gdal.OpenEx(base_raster_path_band[0], gdal.OF_RASTER)
+            srs = base_raster.GetSpatialRef()
+            if srs.IsGeographic():
+                LOGGER.warning(
+                    f'Raster {base_raster_path_band[0]} has a geographic CRS. '
+                    'Because `raster_band_percentile` calculates percentiles '
+                    'of pixel values, percentile results may be skewed.')
+        finally:
+            base_raster = None
 
     numpy_type = pygeoprocessing.get_raster_info(
         base_raster_path_band[0])['numpy_type']

--- a/src/pygeoprocessing/geoprocessing_core.pyx
+++ b/src/pygeoprocessing/geoprocessing_core.pyx
@@ -682,7 +682,7 @@ ctypedef FastFileIterator[double]* FastFileIteratorDoublePtr
 def raster_band_percentile(
         base_raster_path_band, working_sort_directory, percentile_list,
         heap_buffer_size=2**28, ffi_buffer_size=2**10):
-    """Calculate percentiles of a raster band.
+    """Calculate percentiles of a raster band based on pixel values.
 
     Parameters:
         base_raster_path_band (tuple): raster path band tuple to a raster
@@ -708,6 +708,15 @@ def raster_band_percentile(
         will select the next element higher than the percentile cutoff).
 
     """
+    g_raster = gdal.OpenEx(base_raster_path_band[0], gdal.OF_RASTER)
+    srs = g_raster.GetSpatialRef()
+    if srs.IsGeographic():
+        LOGGER.warning(
+            f'Raster {base_raster_path_band[0]} has a geographic CRS (pixels '
+            'do not have equal area). Because `raster_band_percentile` calculates '
+            'percentiles of pixel values, percentile results will be skewed.')
+    g_raster = None
+
     numpy_type = pygeoprocessing.get_raster_info(
         base_raster_path_band[0])['numpy_type']
     if numpy.issubdtype(numpy_type, numpy.integer):

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -4460,7 +4460,8 @@ class TestGeoprocessing(unittest.TestCase):
                 logging.getLogger('pygeoprocessing')) as log_messages:
             pygeoprocessing.raster_band_percentile(
                 (geo_raster_path, 1), working_dir, percentile_cutoffs,
-                heap_buffer_size=8, ffi_buffer_size=4)
+                heap_buffer_size=8, ffi_buffer_size=4,
+                geographic_crs_warn=True)
         self.assertEqual(len(log_messages), 1)
         self.assertEqual(log_messages[0].levelno, logging.WARNING)
         self.assertIn('geographic CRS', log_messages[0].msg)
@@ -4469,7 +4470,8 @@ class TestGeoprocessing(unittest.TestCase):
                 logging.getLogger('pygeoprocessing')) as log_messages:
             pygeoprocessing.raster_band_percentile(
                 (proj_raster_path, 1), working_dir, percentile_cutoffs,
-                heap_buffer_size=8, ffi_buffer_size=4)
+                heap_buffer_size=8, ffi_buffer_size=4,
+                geographic_crs_warn=True)
         self.assertEqual(len(log_messages), 0)
 
         self.assertTrue(


### PR DESCRIPTION
Fixes #299 

- Update docstring to specify percentiles are calculated based on pixel values
- Check if raster CRS is geographic; if so, log a warning
- Add a test case to check logging