### PR TITLE
address deprecation warnings seen in tests

### DIFF
--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -4079,15 +4079,17 @@ def _convolve_2d_worker(
 
         # add zero padding so FFT is fast
         fshape = [_next_regular(int(d)) for d in shape]
+        f_axes_seq = range(len(fshape))
 
-        signal_fft = numpy.fft.rfftn(signal_block, fshape)
-        kernel_fft = numpy.fft.rfftn(kernel_block, fshape)
+        signal_fft = numpy.fft.rfftn(signal_block, fshape, f_axes_seq)
+        kernel_fft = numpy.fft.rfftn(kernel_block, fshape, f_axes_seq)
 
         # this variable determines the output slice that doesn't include
         # the padded array region made for fast FFTs.
         fslice = tuple([slice(0, int(sz)) for sz in shape])
         # classic FFT convolution
-        result = numpy.fft.irfftn(signal_fft * kernel_fft, fshape)[fslice]
+        result = numpy.fft.irfftn(
+            signal_fft * kernel_fft, fshape, f_axes_seq)[fslice]
         # nix any roundoff error
         if set_tol_to_zero is not None:
             result[numpy.isclose(result, set_tol_to_zero)] = 0.0
@@ -4096,9 +4098,9 @@ def _convolve_2d_worker(
         # nodata mask too
         if ignore_nodata:
             mask_fft = numpy.fft.rfftn(
-                numpy.where(signal_nodata_mask, 0.0, 1.0), fshape)
+                numpy.where(signal_nodata_mask, 0.0, 1.0), fshape, f_axes_seq)
             mask_result = numpy.fft.irfftn(
-                mask_fft * kernel_fft, fshape)[fslice]
+                mask_fft * kernel_fft, fshape, f_axes_seq)[fslice]
 
         left_index_result = 0
         right_index_result = result.shape[1]

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -1929,7 +1929,7 @@ class TestGeoprocessing(unittest.TestCase):
         base_a_raster_info = pygeoprocessing.get_raster_info(base_a_path)
         pygeoprocessing.warp_raster(
             base_a_path, base_a_raster_info['pixel_size'], target_raster_path,
-            'near', vector_mask_options={'mask_raster_path': mask_raster_path})
+            'near', mask_options={'mask_raster_path': mask_raster_path})
 
         expected_matrix = numpy.ones((5, 5), numpy.int16)
         expected_matrix[0, 0] = target_nodata
@@ -4205,7 +4205,7 @@ class TestGeoprocessing(unittest.TestCase):
             resample_method_list,
             base_a_raster_info['pixel_size'], bounding_box_mode,
             raster_align_index=0,
-            vector_mask_options={
+            mask_options={
                 'mask_vector_path': dual_poly_path,
                 'mask_layer_name': 'dual_poly',
             },
@@ -4223,7 +4223,7 @@ class TestGeoprocessing(unittest.TestCase):
             resample_method_list,
             base_a_raster_info['pixel_size'], bounding_box_mode,
             raster_align_index=0,
-            vector_mask_options={
+            mask_options={
                 'mask_vector_path': dual_poly_path,
                 'mask_layer_name': 'dual_poly',
                 'mask_vector_where_filter': 'value=1',
@@ -4279,7 +4279,7 @@ class TestGeoprocessing(unittest.TestCase):
             (111000/2, -111000/2), poly_bb_transform,
             raster_align_index=0,
             target_projection_wkt=utm_31w_srs.ExportToWkt(),
-            vector_mask_options={
+            mask_options={
                 'mask_vector_path': poly_path,
                 'mask_layer_name': 'poly',
                 'mask_vector_where_filter': 'value=100'
@@ -4335,7 +4335,7 @@ class TestGeoprocessing(unittest.TestCase):
                 resample_method_list,
                 base_a_raster_info['pixel_size'], bounding_box_mode,
                 raster_align_index=0,
-                vector_mask_options={
+                mask_options={
                     'mask_vector_path': dual_poly_path,
                     'mask_layer_name': 'dual_poly',
                 })
@@ -4349,7 +4349,7 @@ class TestGeoprocessing(unittest.TestCase):
                 resample_method_list,
                 base_a_raster_info['pixel_size'], bounding_box_mode,
                 raster_align_index=0,
-                vector_mask_options={
+                mask_options={
                     'bad_mask_vector_path': dual_poly_path,
                     'mask_layer_name': 'dual_poly',
                 })
@@ -4361,7 +4361,7 @@ class TestGeoprocessing(unittest.TestCase):
             pygeoprocessing.warp_raster(
                 base_a_path, base_a_raster_info['pixel_size'],
                 target_path, 'near',
-                vector_mask_options={
+                mask_options={
                     'bad_mask_vector_path': dual_poly_path,
                     'mask_layer_name': 'dual_poly',
                 })
@@ -4373,7 +4373,7 @@ class TestGeoprocessing(unittest.TestCase):
             pygeoprocessing.warp_raster(
                 base_a_path, base_a_raster_info['pixel_size'],
                 target_path, 'near',
-                vector_mask_options={
+                mask_options={
                     'mask_vector_path': 'not_a_file.shp',
                     'mask_layer_name': 'dual_poly',
                 })


### PR DESCRIPTION
Fixes #425

The `numpy` warnings are addressed by passing the `axes` parameter to FFT calls, retaining the same behavior.

`pygeoprocessing` warnings are addressed by updating the parameter passed to `warp_raster` and `align_and_resize` in tests.