### PR TITLE
raster_calculator stats to include percentage of valid pixels

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+.. Unreleased Changes
+* ``raster_calculator`` ``calc_raster_stats=True`` will count the number
+  of non-nodata pixels in the target raster and write
+  'STATISTICS_VALID_PERCENT' metadata along with other stats.
+  https://github.com/natcap/pygeoprocessing/issues/431
+
 2.4.8 (2025-05-02)
 ------------------
 * ``zonal_statistics`` raises an error if the vector is not a Polygon

--- a/docs/environment-rtd.yml
+++ b/docs/environment-rtd.yml
@@ -8,7 +8,7 @@ name: env-readthedocs
 channels:
     - conda-forge
 dependencies:
-    - python=3.8
+    - python=3.12
     - gdal>=3
     - numpy
     - rtree

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -535,9 +535,6 @@ def raster_calculator(
                     target_band.SetMetadataItem(
                         'STATISTICS_VALID_PERCENT',
                         f'{(valid_pixel_count / n_pixels * 100):.2f}')
-                    # If you ask GDAL to compute stats, you can choose to
-                    # approximate or not. We do not approximate here.
-                    target_band.SetMetadataItem('STATISTICS_APPROXIMATE', 'NO')
                     target_band.FlushCache()
         except Exception:
             LOGGER.exception('exception encountered in raster_calculator')

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2375,18 +2375,19 @@ class TestGeoprocessing(unittest.TestCase):
 
     def test_raster_calculator_stats(self):
         """PGP.geoprocessing: raster_calculator test stats are saved."""
-        pixel_matrix = numpy.ones((5, 5), numpy.int16)
+        blocksize = 5
+        pixel_matrix = numpy.ones((blocksize*2, blocksize*2), numpy.int16)
         target_nodata = -1
         pixel_matrix[:1] = target_nodata
         base_path = os.path.join(self.workspace_dir, 'base.tif')
         _array_to_raster(pixel_matrix, target_nodata, base_path)
 
         target_path = os.path.join(self.workspace_dir, 'subdir', 'target.tif')
-
+        # Test with multiple blocks by limiting largest_block
         pygeoprocessing.raster_calculator(
             [(base_path, 1)], passthrough, target_path,
             gdal.GDT_Int32, target_nodata, calc_raster_stats=True,
-            use_shared_memory=True)
+            use_shared_memory=True, largest_block=blocksize)
 
         raster = gdal.OpenEx(target_path)
         band = raster.GetRasterBand(1)
@@ -2397,7 +2398,7 @@ class TestGeoprocessing(unittest.TestCase):
             'STATISTICS_MAXIMUM': '1',
             'STATISTICS_MEAN': '1',
             'STATISTICS_STDDEV': '0',
-            'STATISTICS_VALID_PERCENT': '80.00'}
+            'STATISTICS_VALID_PERCENT': '90.00'}
         for key, value in expected_metadata.items():
             self.assertIn(key, metadata)
             self.assertEqual(metadata[key], value)

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2397,8 +2397,7 @@ class TestGeoprocessing(unittest.TestCase):
             'STATISTICS_MAXIMUM': '1',
             'STATISTICS_MEAN': '1',
             'STATISTICS_STDDEV': '0',
-            'STATISTICS_VALID_PERCENT': '80.00',
-            'STATISTICS_APPROXIMATE': 'NO'}
+            'STATISTICS_VALID_PERCENT': '80.00'}
         for key, value in expected_metadata.items():
             self.assertIn(key, metadata)
             self.assertEqual(metadata[key], value)

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2373,6 +2373,36 @@ class TestGeoprocessing(unittest.TestCase):
                 pygeoprocessing.raster_to_numpy_array(base_path),
                 pygeoprocessing.raster_to_numpy_array(target_path)).all())
 
+    def test_raster_calculator_stats(self):
+        """PGP.geoprocessing: raster_calculator test stats are saved."""
+        pixel_matrix = numpy.ones((5, 5), numpy.int16)
+        target_nodata = -1
+        pixel_matrix[:1] = target_nodata
+        base_path = os.path.join(self.workspace_dir, 'base.tif')
+        _array_to_raster(pixel_matrix, target_nodata, base_path)
+
+        target_path = os.path.join(self.workspace_dir, 'subdir', 'target.tif')
+
+        pygeoprocessing.raster_calculator(
+            [(base_path, 1)], passthrough, target_path,
+            gdal.GDT_Int32, target_nodata, calc_raster_stats=True,
+            use_shared_memory=True)
+
+        raster = gdal.OpenEx(target_path)
+        band = raster.GetRasterBand(1)
+        metadata = band.GetMetadata()
+        raster = band = None
+        expected_metadata = {  # gdal metadata are represented as strings
+            'STATISTICS_MINIMUM': '1',
+            'STATISTICS_MAXIMUM': '1',
+            'STATISTICS_MEAN': '1',
+            'STATISTICS_STDDEV': '0',
+            'STATISTICS_VALID_PERCENT': '80.00',
+            'STATISTICS_APPROXIMATE': 'NO'}
+        for key, value in expected_metadata.items():
+            self.assertIn(key, metadata)
+            self.assertEqual(metadata[key], value)
+
     def test_raster_calculator_multiprocessing(self):
         """PGP.geoprocessing: raster_calculator identity test."""
         pixel_matrix = numpy.ones((1024, 1024), numpy.int16)


### PR DESCRIPTION
Fixes #431 

This follows GDAL conventions & behavior for what gets written to the band metadata when `band.ComputeStatistics(0)` is called.