### PR TITLE
Watershed delineation will now always create multipolygons

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,11 @@
 Release History
 ===============
 
-.. Unreleased Changes
+Unreleased Changes
+------------------
+* Watershed delineation will now always create a layer of type MultiPolygon.
+  All features contained in this layer will subsequently be MultiPolygons.
+  https://github.com/natcap/pygeoprocessing/issues/435
 
 2.4.7 (2025-01-23)
 ------------------

--- a/src/pygeoprocessing/routing/watershed.pyx
+++ b/src/pygeoprocessing/routing/watershed.pyx
@@ -729,14 +729,12 @@ def delineate_watersheds_d8(
     polygonized_watersheds_layer = watersheds_vector.CreateLayer(
         'polygonized_watersheds', watersheds_srs, ogr.wkbPolygon)
 
-    # Using wkbUnknown layer data type because it's possible for a single
-    # watershed to have several disjoint components, and inserting a
-    # Polygon geometry into a MultiPolygon layer (or vice versa) is
-    # technically not supported by the GPKG standard although GDAL
-    # allows it for the time being.
-    temp_layer_name = f'{target_layer_name}_TEMP'
+    # Using wkbMultiPolygon for this layer because GDAL's polygonize function
+    # may create multiple polygons for a single watershed feature, and we want
+    # all geometries for a single watershed to be represented in a single
+    # feature.
     watersheds_layer = watersheds_vector.CreateLayer(
-        temp_layer_name, watersheds_srs, ogr.wkbUnknown)
+        target_layer_name, watersheds_srs, ogr.wkbMultiPolygon)
     index_field = ogr.FieldDefn('ws_id', ogr.OFTInteger)
     index_field.SetWidth(24)
     polygonized_watersheds_layer.CreateField(index_field)
@@ -1001,7 +999,7 @@ def delineate_watersheds_d8(
                 new_geometry.AddGeometry(duplicate_geometry)
 
         watershed_feature = ogr.Feature(watersheds_layer.GetLayerDefn())
-        watershed_feature.SetGeometry(new_geometry)
+        watershed_feature.SetGeometry(ogr.ForceToMultiPolygon(new_geometry))
 
         source_feature = source_layer.GetFeature(ws_id)
         for field_name, field_value in source_feature.items().items():
@@ -1009,57 +1007,10 @@ def delineate_watersheds_d8(
         watersheds_layer.CreateFeature(watershed_feature)
     watersheds_layer.CommitTransaction()
 
-    # Polygonization may create Polygon and/or MultiPolygon features, so we
-    # need to go back through and make sure that we have only 1 geometry type
-    # and that this is reflected in the layer's geometry type.
-    detected_watershed_types = set()
-    for feature in watersheds_layer:
-        geometry = feature.GetGeometryRef()
-        detected_watershed_types.add(geometry.GetGeometryType())
-
-    LOGGER.debug(f'Detected watershed geometry types (bitwise-or): {detected_watershed_types}')
-
-    if len(detected_watershed_types) == 1:
-        # we only have 1 type to deal with, so we can just create the vector
-        # using this geometry type and copy features over.
-        new_layer_type = detected_watershed_types.next()
-        cast_to_multipolygon = False
-    else:
-        # If we have more than 1 type to deal with, log the types and convert
-        # all features to multipolygon.
-        new_layer_type = ogr.wkbMultiPolygon
-        cast_to_multipolygon = True
-
-    # This created layer is the final output layer.
-    final_watersheds_layer = watersheds_vector.createLayer(
-        target_layer_name, watersheds_srs, new_layer_type)
-    index_field = ogr.FieldDefn('ws_id', ogr.OFTInteger)
-    index_field.setWidth(24)
-    final_watersheds_layer.CreateField(index_field)
-
-    for feature in watersheds_layer:
-        geometry = feature.GetGeometryRef()
-        new_feature = ogr.Feature(final_watersheds_layer.GetLayerDefn())
-        new_feature.SetField('ws_id', feature.GetField('ws_id'))
-        if cast_to_multipolygon:
-            geometry = ogr.ForceToMultiPolygon(geometry)
-        new_feature.SetGeometry(geometry)
-        final_watersheds_layer.CreateFeature(new_feature)
-
-    LOGGER.info(
-        'Consolidating %s fragments and copying field values to '
-        'watersheds layer.', polygonized_watersheds_layer.GetFeatureCount())
-    source_vector = gdal.OpenEx(outflow_vector_path, gdal.OF_VECTOR)
-    source_layer = source_vector.GetLayer()
-    watersheds_layer.CreateFields(source_layer.schema)
-
-
     polygonized_watersheds_layer = None
     watersheds_layer = None
-    final_watersheds_layer = None
     if remove_temp_files:
         watersheds_vector.DeleteLayer('polygonized_watersheds')
-        watersheds_vector.DeleteLayer(temp_layer_name)
     LOGGER.info('Finished vector consolidation')
 
     watersheds_vector = None

--- a/tests/test_watershed_delineation.py
+++ b/tests/test_watershed_delineation.py
@@ -176,7 +176,12 @@ class WatershedDelineationTests(unittest.TestCase):
                                                 gdal.OF_VECTOR)
                 watersheds_layer = watersheds_vector.GetLayer(
                     'watersheds_something')
+                for feature in watersheds_layer:
+                    geom = feature.GetGeometryRef()
+                    print(geom.ExportToWkt())
                 self.assertEqual(watersheds_layer.GetFeatureCount(), 4)
+                self.assertEqual(watersheds_layer.GetGeomType(),
+                                 ogr.wkbMultiPolygon)
 
                 # All features should have the same watersheds, both in area
                 # and geometry.

--- a/tests/test_watershed_delineation.py
+++ b/tests/test_watershed_delineation.py
@@ -195,7 +195,7 @@ class WatershedDelineationTests(unittest.TestCase):
                 pygeoprocessing.shapely_geometry_to_vector(
                     [expected_watershed_geometry],
                     os.path.join(self.workspace_dir, 'foo.gpkg'), srs_wkt,
-                    'GPKG', ogr_geom_type=ogr.wkbGeometryCollection)
+                    'GPKG', ogr_geom_type=ogr.wkbPolygon)
 
                 id_to_fields = {}
                 for feature in watersheds_layer:

--- a/tests/test_watershed_delineation.py
+++ b/tests/test_watershed_delineation.py
@@ -176,9 +176,6 @@ class WatershedDelineationTests(unittest.TestCase):
                                                 gdal.OF_VECTOR)
                 watersheds_layer = watersheds_vector.GetLayer(
                     'watersheds_something')
-                for feature in watersheds_layer:
-                    geom = feature.GetGeometryRef()
-                    print(geom.ExportToWkt())
                 self.assertEqual(watersheds_layer.GetFeatureCount(), 4)
                 self.assertEqual(watersheds_layer.GetGeomType(),
                                  ogr.wkbMultiPolygon)
@@ -203,6 +200,8 @@ class WatershedDelineationTests(unittest.TestCase):
                 id_to_fields = {}
                 for feature in watersheds_layer:
                     geometry = feature.GetGeometryRef()
+                    self.assertEqual(geometry.GetGeometryType(),
+                                     ogr.wkbMultiPolygon)
                     shapely_geom = shapely.wkb.loads(
                         bytes(geometry.ExportToWkb()))
                     self.assertEqual(


### PR DESCRIPTION
Now, all geometries created by `watershed_delineation` will be of type `ogr.wkbMultiPolygon`.  If any `Polygon` geometries are created, they are upgraded to `MultiPolygon` geometries.

I confirmed that this fixes https://github.com/natcap/invest/issues/2067

Fixes #435 