### PR TITLE
Expand `zonal_statistics` supported geometry types

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,10 @@ Unreleased Changes
   class (which was previously implemented in Cython).
   https://github.com/natcap/pygeoprocessing/issues/439
 
+* Added support for 3D, Measured, and 3D Measured Polygon and MultiPolygon
+  geometries to ``zonal_statistics``.
+  https://github.com/natcap/pygeoprocessing/issues/448
+
 2.4.9 (2025-07-10)
 ------------------
 * Watershed delineation will now always create a layer of type MultiPolygon.

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1667,7 +1667,7 @@ def zonal_statistics(
 
         ValueError
             if ``aggregate_vector_path`` has a geometry type other than
-            Polygon or MultiPolygon
+            2D/Measured/3D/3D-Measured Polygon or MultiPolygon
 
         RuntimeError
             if the aggregate vector or layer cannot be opened

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1709,8 +1709,10 @@ def zonal_statistics(
             f"Could not open layer {aggregate_layer_name} of {aggregate_vector_path}")
 
     # Check that the vector geometry type is polygon or multipolygon
-    if aggregate_layer.GetGeomType() not in [ogr.wkbPolygon, ogr.wkbMultiPolygon]:
-        raise ValueError('Vector geometry type must be Polygon or MultiPolygon')
+    if aggregate_layer.GetGeomType() not in [ogr.wkbPolygon, ogr.wkbPolygonM,
+            ogr.wkbPolygonZM, ogr.wkbPolygon25D, ogr.wkbMultiPolygon,
+            ogr.wkbMultiPolygonM, ogr.wkbMultiPolygonZM, ogr.wkbMultiPolygon25D]:
+        raise ValueError(f'Vector geometry type must be Polygon or MultiPolygon')
 
     # Define the default/empty statistics values
     # These values will be returned for features that have no geometry or

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -1353,23 +1353,23 @@ class TestGeoprocessing(unittest.TestCase):
 
         polygon_a = [
             (origin[0], origin[1]),
-            (origin[0], -pixel_size * n_pixels+origin[1]),
-            (origin[0]+pixel_size * n_pixels,
-             -pixel_size * n_pixels+origin[1]),
-            (origin[0]+pixel_size * n_pixels, origin[1]),
+            (origin[0], -pixel_size * n_pixels + origin[1]),
+            (origin[0] + pixel_size * n_pixels,
+             -pixel_size * n_pixels + origin[1]),
+            (origin[0] + pixel_size * n_pixels, origin[1]),
             (origin[0], origin[1])]
         polygon_b = [
             (origin[0], origin[1]),
-            (origin[0], -pixel_size+origin[1]),
-            (origin[0]+pixel_size, -pixel_size+origin[1]),
-            (origin[0]+pixel_size, origin[1]),
+            (origin[0], -pixel_size + origin[1]),
+            (origin[0] + pixel_size, -pixel_size + origin[1]),
+            (origin[0] + pixel_size, origin[1]),
             (origin[0], origin[1])]
         polygon_c = [
             (origin[1]*2, origin[1]*3),
-            (origin[1]*2, -pixel_size+origin[1]*3),
-            (origin[1]*2+pixel_size,
-             -pixel_size+origin[1]*3),
-            (origin[1]*2+pixel_size, origin[1]*3),
+            (origin[1]*2, -pixel_size + origin[1]*3),
+            (origin[1]*2 + pixel_size,
+             -pixel_size + origin[1]*3),
+            (origin[1]*2 + pixel_size, origin[1]*3),
             (origin[1]*2, origin[1]*3)]
 
         layer.StartTransaction()

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -1347,7 +1347,8 @@ class TestGeoprocessing(unittest.TestCase):
 
         projection = osr.SpatialReference()
         projection.ImportFromEPSG(3116)
-        layer = vector.CreateLayer('aggregate', srs=projection, geom_type=ogr.wkbPolygon25D)
+        layer = vector.CreateLayer('aggregate', srs=projection,
+                                   geom_type=ogr.wkbPolygon25D)
         layer_defn = layer.GetLayerDefn()
 
         polygon_a = [
@@ -1478,33 +1479,33 @@ class TestGeoprocessing(unittest.TestCase):
         projection = osr.SpatialReference()
         projection.ImportFromEPSG(3116)
         layer = vector.CreateLayer('aggregate', srs=projection,
-                                   geom_type=ogr.wkbMultiPolygon25D)
+                                   geom_type=ogr.wkbMultiPolygonZM)
         layer_defn = layer.GetLayerDefn()
 
         origin = (444720, 3751320)
         polygon_a = [
-            (origin[0], origin[1]),
-            (origin[0], -pixel_size + origin[1]),
-            (origin[0] + pixel_size, -pixel_size + origin[1]),
-            (origin[0] + pixel_size, origin[1]),
-            (origin[0], origin[1])]
+            (origin[0], origin[1], 0, 1),
+            (origin[0], -pixel_size + origin[1], 0, 2),
+            (origin[0] + pixel_size, -pixel_size + origin[1], 0, 0),
+            (origin[0] + pixel_size, origin[1], 0, 0),
+            (origin[0], origin[1], 0, 1)]
         origin = (origin[0] + pixel_size, origin[1] - pixel_size)
         polygon_b = [
-            (origin[0], origin[1]),
-            (origin[0], -pixel_size + origin[1]),
-            (origin[0] + pixel_size, -pixel_size + origin[1]),
-            (origin[0] + pixel_size, origin[1]),
-            (origin[0], origin[1])]
+            (origin[0], origin[1], 0, 0),
+            (origin[0], -pixel_size + origin[1], 0, 1),
+            (origin[0] + pixel_size, -pixel_size + origin[1], 0, 2),
+            (origin[0] + pixel_size, origin[1], 0, 1),
+            (origin[0], origin[1], 0, 0)]
 
-        multipolygon = ogr.Geometry(ogr.wkbMultiPolygon25D)
+        multipolygon = ogr.Geometry(ogr.wkbMultiPolygonZM)
 
         layer.StartTransaction()
         for polygon in [polygon_a, polygon_b]:
             ring = ogr.Geometry(ogr.wkbLinearRing)
             for coords in polygon:
-                ring.AddPoint(coords[0], coords[1], 0)
+                ring.AddPointZM(coords[0], coords[1], coords[2], coords[3])
 
-            poly = ogr.Geometry(ogr.wkbPolygon25D)
+            poly = ogr.Geometry(ogr.wkbPolygonZM)
             poly.AddGeometry(ring)
             multipolygon.AddGeometry(poly)
 
@@ -1515,7 +1516,7 @@ class TestGeoprocessing(unittest.TestCase):
         layer.CommitTransaction()
         layer.SyncToDisk()
         self.assertEqual(ogr.GeometryTypeToName(layer.GetGeomType()),
-                         ogr.GeometryTypeToName(ogr.wkbMultiPolygon25D))
+                         ogr.GeometryTypeToName(ogr.wkbMultiPolygonZM))
         layer = None
         vector = None
 


### PR DESCRIPTION
Fixes #448 

`zonal_statistics` previously only supported `wkbPolygon` and `wkbMultiPolygon` geometries. However, it would be reasonable to support 3D and measured (multi)polygons as well, as the z coordinates shouldn't have an affect / should be ignored for the purposes of the zonal stats calculations. 

This change also brings `zonal_statistics` in line with InVEST validation of input vectors, where the model spec input `geometry_types` maps `'POLYGON'` and `'MULTIPOLYGON'` to several ogr types:
```
'POLYGON': [ogr.wkbPolygon, ogr.wkbPolygonM,
            ogr.wkbPolygonZM, ogr.wkbPolygon25D],
'MULTIPOLYGON': [ogr.wkbMultiPolygon, ogr.wkbMultiPolygonM,
                 ogr.wkbMultiPolygonZM, ogr.wkbMultiPolygon25D]
```
Allowing for the same list of valid geometries will prevent InVEST models that calculate `zonal_statistics` from failing on vectors that would otherwise be valid InVEST inputs. 