### PR TITLE
Restore building wheels against each supported python version

### DIFF
--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -41,7 +41,7 @@ jobs:
                   channels:
                     - conda-forge
                 create-args: >-
-                  python=3.13
+                  python=${{ matrix.python-version }}
                   gdal
                   setuptools
                   python-build


### PR DESCRIPTION
Fixes #456 

Brings back the reference to `${{ matrix.python-version }}` when creating the micromamba environment, so that we can build wheels against each supported Python version.