### PR TITLE
Update NatCap's name and website URL

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,13 @@
 Release History
 ===============
 
+Unreleased Changes
+------------------
+* The Natural Capital Project changed its name to the Natural Capital Alliance.
+  References to the old name and website domain have been updated to reflect
+  this change.
+  https://github.com/natcap/pygeoprocessing/issues/458
+
 2.4.10 (2026-01-13)
 -------------------
 * A new module, ``pygeoprocessing.extensions``, exposes the C++ extensions

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ commonly used raster, vector, and hydrological operations for GIS processing.
 Similar functionality can be found in ArcGIS/QGIS raster algebra, ArcGIS zonal
 statistics, and ArcGIS/GRASS/TauDEM hydrological routing routines.
 
-PyGeoprocessing is developed at the Natural Capital Project to create a
+PyGeoprocessing is developed at the Natural Capital Alliance to create a
 programmable, open source, and free Python based GIS processing library to
 support the InVEST toolset.  PyGeoprocessing's design prioritizes
 computation and memory efficient runtimes, easy installation and cross

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,8 +20,8 @@ from pkg_resources import get_distribution
 # -- Project information -----------------------------------------------------
 
 project = 'PyGeoprocessing'
-copyright = f'{datetime.datetime.today().year}, The Natural Capital Project'
-author = 'The Natural Capital Project'
+copyright = f'{datetime.datetime.today().year}, The Natural Capital Alliance'
+author = 'The Natural Capital Alliance'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ commonly used raster, vector, and hydrological operations for GIS processing.
 Similar functionality can be found in ArcGIS/QGIS raster algebra, ArcGIS zonal
 statistics, and ArcGIS/GRASS/TauDEM hydrological routing routines.
 
-PyGeoprocessing is developed at the Natural Capital Project to create a
+PyGeoprocessing is developed at the Natural Capital Alliance to create a
 programmable, open source, and free Python based GIS processing library to
 support the InVEST toolset. PyGeoprocessing's design prioritizes computation
 and memory efficient runtimes, easy installation and cross compatibility with
@@ -25,7 +25,7 @@ Specifically the functionally provided by PyGeoprocessing includes:
       plateau drainage, weighted and unweighted flow accumulation, and weighted
       and unweighted flow distance)
 
-PyGeoprocessing is developed by the `Natural Capital Project <https://naturalcapitalproject.stanford.edu>`_.
+PyGeoprocessing is developed by the `Natural Capital Alliance <https://naturalcapitalalliance.stanford.edu>`_.
 
 
 Getting Started

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "PyGeoprocessing: Geoprocessing routines for GIS"
 requires-python = ">=3.6"
 license = {file = "LICENSE.txt"}
 maintainers = [
-    {name = "Natural Capital Project Software Team"}
+    {name = "Natural Capital Alliance Software Team"}
 ]
 keywords = ['gis', 'geoprocessing', 'pygeoprocessing']
 classifiers = [

--- a/src/pygeoprocessing/extensions/FastFileIterator.h
+++ b/src/pygeoprocessing/extensions/FastFileIterator.h
@@ -1,4 +1,4 @@
-// Copyright 2019 The Natural Capital Project
+// Copyright 2026 The Natural Capital Alliance
 #ifndef SRC_PYGEOPROCESSING_FASTFILEITERATOR_H_
 #define SRC_PYGEOPROCESSING_FASTFILEITERATOR_H_
 


### PR DESCRIPTION
Fixes #458 

This PR updates NatCap's name and website URL throughout the API docs, README, and pyproject.toml to reflect the Natural Capital Alliance name change.

This PR does **not** update `LICENSE.txt`

@phargogh One question that you may be able to answer: `src/pygeoprocessing/extensions/FastFileIterator.h` includes its own copyright line at the top of the file: `Copyright 2019 The Natural Capital Project`. I assume there was a historical reason for this, but should it still be there? And if so, should it get updated? 