### PR TITLE
Correcting classifier usage

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,9 @@ Unreleased Changes
   References to the old name and website domain have been updated to reflect
   this change.
   https://github.com/natcap/pygeoprocessing/issues/458
+* Updating pyproject.toml to use the standard ``license-files`` key and
+  replacing the license-related Trove classifier with the approved SPDX string.
+  https://github.com/natcap/pygeoprocessing/issues/466
 
 2.4.10 (2026-01-13)
 -------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 name = "pygeoprocessing"
 description = "PyGeoprocessing: Geoprocessing routines for GIS"
 requires-python = ">=3.6"
-license = {file = "LICENSE.txt"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE.txt"]
 maintainers = [
     {name = "Natural Capital Alliance Software Team"}
 ]
@@ -22,7 +23,6 @@ classifiers = [
     'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: Implementation :: CPython',
     'Topic :: Scientific/Engineering :: GIS',
-    'License :: OSI Approved :: BSD License'
 ]
 # the version is provided dynamically by setuptools_scm
 # `dependencies` and `optional-dependencies` are provided by setuptools


### PR DESCRIPTION
Just updating to the latest standard keywords in pyproject.toml and removing the license classification from the Trove classifiers.  Fixes: #466

Readthedocs build failures are addressed in #470