### PR TITLE
Updating how we get version information in Sphinx docs builds

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,9 @@ Unreleased Changes
   References to the old name and website domain have been updated to reflect
   this change.
   https://github.com/natcap/pygeoprocessing/issues/458
+* Fixing a build issue with readthedocs builds due to the deprecation of
+  ``pkg_resources``.
+  https://github.com/natcap/pygeoprocessing/issues/469
 
 2.4.10 (2026-01-13)
 -------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,16 +6,17 @@
 
 # -- Path setup --------------------------------------------------------------
 
+import datetime
+import os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
-import datetime
-import os
+from importlib.metadata import version
+
 import sphinx.ext.apidoc
-from pkg_resources import get_distribution
 
 # -- Project information -----------------------------------------------------
 
@@ -77,5 +78,5 @@ sphinx.ext.apidoc.main([
     os.path.join(DOCS_SOURCE_DIR, '..', '..', 'src', 'pygeoprocessing'),
 ])
 
-release = get_distribution('pygeoprocessing').version
+release = version('pygeoprocessing')
 version = '.'.join(release.split('.')[:2])


### PR DESCRIPTION
Just a small PR to correct how package version metadata is fetched in the readthedocs build.

Fixes #469 

