### PR TITLE
Handle rasters without a defined `NoData` value in `warp_raster`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -26,6 +26,11 @@ Unreleased Changes
 * Fixed a bug where ``convolve_2d`` was not handling ``nan`` NoData
   values correctly.
   https://github.com/natcap/pygeoprocessing/issues/473
+* Fixed a bug where ``align_and_resize_raster_stack`` would pad rasters that
+  were smaller than the target extent and didn't have a defined NoData value
+  with 0s. The function will now automatically assign an appropriate NoData
+  value to any input raster without one defined.
+  https://github.com/natcap/pygeoprocessing/issues/476
 
 2.4.10 (2026-01-13)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 Release History
 ===============
 
+Unreleased Changes
+------------------
+* ``warp_raster`` will now automatically assign an appropriate NoData value
+  to any input raster without one defined. This fixes a bug where
+  ``align_and_resize_raster_stack`` would pad rasters that were smaller
+  than the target extent and didn't have a defined NoData value with 0s.
+  https://github.com/natcap/pygeoprocessing/issues/476
+
 2.4.11 (2026-04-10)
 -------------------
 * The Natural Capital Project changed its name to the Natural Capital Alliance.
@@ -26,11 +34,6 @@ Release History
 * Fixed a bug where ``convolve_2d`` was not handling ``nan`` NoData
   values correctly.
   https://github.com/natcap/pygeoprocessing/issues/473
-* ``warp_raster`` will now automatically assign an appropriate NoData value
-  to any input raster without one defined. This fixes a bug where
-  ``align_and_resize_raster_stack`` would pad rasters that were smaller
-  than the target extent and didn't have a defined NoData value with 0s.
-  https://github.com/natcap/pygeoprocessing/issues/476
 
 2.4.10 (2026-01-13)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -26,10 +26,10 @@ Unreleased Changes
 * Fixed a bug where ``convolve_2d`` was not handling ``nan`` NoData
   values correctly.
   https://github.com/natcap/pygeoprocessing/issues/473
-* Fixed a bug where ``align_and_resize_raster_stack`` would pad rasters that
-  were smaller than the target extent and didn't have a defined NoData value
-  with 0s. The function will now automatically assign an appropriate NoData
-  value to any input raster without one defined.
+* ``warp_raster`` will now automatically assign an appropriate NoData value
+  to any input raster without one defined. This fixes a bug where
+  ``align_and_resize_raster_stack`` would pad rasters that were smaller
+  than the target extent and didn't have a defined NoData value with 0s.
   https://github.com/natcap/pygeoprocessing/issues/476
 
 2.4.10 (2026-01-13)

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1102,6 +1102,49 @@ def align_and_resize_raster_stack(
                 n_pixels * align_pixel_size[index] +
                 align_bounding_box[index])
 
+    # Set a nodata value if the raster does not have one defined. This
+    # ensures that a raster that is smaller than the target extent will
+    # not get filled with 0s that could be confused with real data.
+    # We do this by creating a temporary VRT with an explicit nodata value
+    # for rasters that are missing one.
+    temp_working_dir_nodata = None
+    fixed_base_raster_path_list = list(base_raster_path_list)
+
+    rasters_missing_nodata = []
+    for raster_info, base_path in zip(raster_info_list, base_raster_path_list):
+        nodata_list = raster_info.get('nodata', [])
+        band_nodata = nodata_list[0] if nodata_list else None
+        if band_nodata is None:
+            rasters_missing_nodata.append(base_path)
+
+    if rasters_missing_nodata:
+        temp_working_dir_nodata = tempfile.mkdtemp(dir=working_dir, prefix='align-nodata-')
+
+        for index, (raster_info, base_path) in enumerate(
+                zip(raster_info_list, base_raster_path_list)):
+            nodata_list = raster_info.get('nodata', [])
+            band_nodata = nodata_list[0] if nodata_list else None
+            if band_nodata is not None:
+                continue
+
+            raster = gdal.OpenEx(base_path, gdal.OF_RASTER)
+            chosen_nodata = choose_nodata(raster_info['numpy_type'])
+
+            vrt_path = os.path.join(temp_working_dir_nodata,
+                                    f'input_with_nodata_{index}.vrt')
+            vrt = gdal.Translate(vrt_path, raster, format='VRT',
+                                 noData=chosen_nodata)
+            vrt = None
+            band = None
+            raster = None
+
+            fixed_base_raster_path_list[index] = vrt_path
+
+            LOGGER.warning(
+                "Input raster %s had no defined nodata value. Using "
+                "%s as nodata in a temporary VRT before warping.",
+                base_path, chosen_nodata)
+
     if mask_options:
         # Create a warped VRT.
         # This allows us to cheaply figure out the dimensions, projection, etc.
@@ -1110,7 +1153,7 @@ def align_and_resize_raster_stack(
         temp_working_dir = tempfile.mkdtemp(dir=working_dir, prefix='mask-')
         warped_vrt = os.path.join(temp_working_dir, 'warped.vrt')
         warp_raster(
-            base_raster_path=base_raster_path_list[0],
+            base_raster_path=fixed_base_raster_path_list[0],
             target_pixel_size=target_pixel_size,
             target_raster_path=warped_vrt,
             resample_method='near',
@@ -1142,7 +1185,7 @@ def align_and_resize_raster_stack(
                       else None))
 
     for index, (base_path, target_path, resample_method) in enumerate(zip(
-            base_raster_path_list, target_raster_path_list,
+            fixed_base_raster_path_list, target_raster_path_list,
             resample_method_list)):
         warp_raster(
             base_path, target_pixel_size, target_path, resample_method,
@@ -1160,6 +1203,8 @@ def align_and_resize_raster_stack(
 
     LOGGER.info("aligned all %d rasters.", n_rasters)
 
+    if rasters_missing_nodata:
+        shutil.rmtree(temp_working_dir_nodata, ignore_errors=True)
     if mask_options:
         shutil.rmtree(temp_working_dir, ignore_errors=True)
 

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -2591,16 +2591,16 @@ def warp_raster(
     base_raster_info = get_raster_info(base_raster_path)
     if target_projection_wkt is None:
         target_projection_wkt = base_raster_info['projection_wkt']
-    source_nodata = " ".join(str(x) for x in base_raster_info['nodata'])
     if None in base_raster_info['nodata']:
-        target_nodata = choose_nodata(base_raster_info['numpy_type'])
+        pgp_nodata = choose_nodata(base_raster_info['numpy_type'])
+        tgt_nodata = " ".join(
+            str(pgp_nodata) for x in range(len(base_raster_info['nodata'])))
         LOGGER.warning(f'One or more bands in {base_raster_path} do not have '
                        'a designated NoData value. All bands in the output '
                        'warped raster will be assigned a NoData value '
-                       f'of {target_nodata}.')
+                       f'of {tgt_nodata}.')
     else:
-        target_nodata = " ".join(str(x) for x in base_raster_info['nodata'])
-
+        tgt_nodata = " ".join(str(x) for x in base_raster_info['nodata'])
     if vector_mask_options is not None:
         warnings.warn('The vector_mask_options parameter is deprecated and '
                       'will be removed in a future release of '
@@ -2713,8 +2713,7 @@ def warp_raster(
         outputBoundsSRS=target_projection_wkt,
         srcSRS=base_projection_wkt,
         dstSRS=target_projection_wkt,
-        srcNodata=source_nodata,
-        dstNodata=target_nodata,
+        dstNodata=tgt_nodata,
         multithread=True if warp_options else False,
         warpOptions=warp_options,
         overviewLevel=use_overview_level,

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1107,43 +1107,38 @@ def align_and_resize_raster_stack(
     # not get filled with 0s that could be confused with real data.
     # We do this by creating a temporary VRT with an explicit nodata value
     # for rasters that are missing one.
-    temp_working_dir_nodata = None
     fixed_base_raster_path_list = list(base_raster_path_list)
-
-    rasters_missing_nodata = []
-    for raster_info, base_path in zip(raster_info_list, base_raster_path_list):
-        nodata_list = raster_info.get('nodata', [])
-        band_nodata = nodata_list[0] if nodata_list else None
-        if band_nodata is None:
-            rasters_missing_nodata.append(base_path)
-
-    if rasters_missing_nodata:
-        temp_working_dir_nodata = tempfile.mkdtemp(dir=working_dir, prefix='align-nodata-')
-
-        for index, (raster_info, base_path) in enumerate(
+    temp_working_dir_nodata = None
+    for index, (raster_info, base_path) in enumerate(
                 zip(raster_info_list, base_raster_path_list)):
-            nodata_list = raster_info.get('nodata', [])
-            band_nodata = nodata_list[0] if nodata_list else None
-            if band_nodata is not None:
-                continue
-
+        nodata_list = raster_info['nodata']
+        if None in nodata_list:
+            if temp_working_dir_nodata is None:
+                temp_working_dir_nodata = tempfile.mkdtemp(dir=working_dir,
+                                               prefix='align-nodata-')
             raster = gdal.OpenEx(base_path, gdal.OF_RASTER)
             chosen_nodata = choose_nodata(raster_info['numpy_type'])
+
+            if set(nodata_list) != {None}:
+                LOGGER.warning(
+                    "Input raster %s has some bands with a defined nodata "
+                    "value and some bands without. Setting %s as the nodata "
+                    "value for all bands in a temporary VRT before aligning "
+                    "and resizing.", base_path, chosen_nodata)
+            else:
+                LOGGER.warning(
+                    "Input raster %s has no defined nodata value. Setting "
+                    "%s as nodata in a temporary VRT before aligning and "
+                    "resizing.", base_path, chosen_nodata)
 
             vrt_path = os.path.join(temp_working_dir_nodata,
                                     f'input_with_nodata_{index}.vrt')
             vrt = gdal.Translate(vrt_path, raster, format='VRT',
                                  noData=chosen_nodata)
             vrt = None
-            band = None
             raster = None
 
             fixed_base_raster_path_list[index] = vrt_path
-
-            LOGGER.warning(
-                "Input raster %s had no defined nodata value. Using "
-                "%s as nodata in a temporary VRT before warping.",
-                base_path, chosen_nodata)
 
     if mask_options:
         # Create a warped VRT.
@@ -1203,7 +1198,7 @@ def align_and_resize_raster_stack(
 
     LOGGER.info("aligned all %d rasters.", n_rasters)
 
-    if rasters_missing_nodata:
+    if temp_working_dir_nodata:
         shutil.rmtree(temp_working_dir_nodata, ignore_errors=True)
     if mask_options:
         shutil.rmtree(temp_working_dir, ignore_errors=True)

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -1102,44 +1102,6 @@ def align_and_resize_raster_stack(
                 n_pixels * align_pixel_size[index] +
                 align_bounding_box[index])
 
-    # Set a nodata value if the raster does not have one defined. This
-    # ensures that a raster that is smaller than the target extent will
-    # not get filled with 0s that could be confused with real data.
-    # We do this by creating a temporary VRT with an explicit nodata value
-    # for rasters that are missing one.
-    fixed_base_raster_path_list = list(base_raster_path_list)
-    temp_working_dir_nodata = None
-    for index, (raster_info, base_path) in enumerate(
-                zip(raster_info_list, base_raster_path_list)):
-        nodata_list = raster_info['nodata']
-        if None in nodata_list:
-            if temp_working_dir_nodata is None:
-                temp_working_dir_nodata = tempfile.mkdtemp(dir=working_dir,
-                                               prefix='align-nodata-')
-            raster = gdal.OpenEx(base_path, gdal.OF_RASTER)
-            chosen_nodata = choose_nodata(raster_info['numpy_type'])
-
-            if set(nodata_list) != {None}:
-                LOGGER.warning(
-                    "Input raster %s has some bands with a defined nodata "
-                    "value and some bands without. Setting %s as the nodata "
-                    "value for all bands in a temporary VRT before aligning "
-                    "and resizing.", base_path, chosen_nodata)
-            else:
-                LOGGER.warning(
-                    "Input raster %s has no defined nodata value. Setting "
-                    "%s as nodata in a temporary VRT before aligning and "
-                    "resizing.", base_path, chosen_nodata)
-
-            vrt_path = os.path.join(temp_working_dir_nodata,
-                                    f'input_with_nodata_{index}.vrt')
-            vrt = gdal.Translate(vrt_path, raster, format='VRT',
-                                 noData=chosen_nodata)
-            vrt = None
-            raster = None
-
-            fixed_base_raster_path_list[index] = vrt_path
-
     if mask_options:
         # Create a warped VRT.
         # This allows us to cheaply figure out the dimensions, projection, etc.
@@ -1148,7 +1110,7 @@ def align_and_resize_raster_stack(
         temp_working_dir = tempfile.mkdtemp(dir=working_dir, prefix='mask-')
         warped_vrt = os.path.join(temp_working_dir, 'warped.vrt')
         warp_raster(
-            base_raster_path=fixed_base_raster_path_list[0],
+            base_raster_path=base_raster_path_list[0],
             target_pixel_size=target_pixel_size,
             target_raster_path=warped_vrt,
             resample_method='near',
@@ -1180,7 +1142,7 @@ def align_and_resize_raster_stack(
                       else None))
 
     for index, (base_path, target_path, resample_method) in enumerate(zip(
-            fixed_base_raster_path_list, target_raster_path_list,
+            base_raster_path_list, target_raster_path_list,
             resample_method_list)):
         warp_raster(
             base_path, target_pixel_size, target_path, resample_method,
@@ -1198,8 +1160,6 @@ def align_and_resize_raster_stack(
 
     LOGGER.info("aligned all %d rasters.", n_rasters)
 
-    if temp_working_dir_nodata:
-        shutil.rmtree(temp_working_dir_nodata, ignore_errors=True)
     if mask_options:
         shutil.rmtree(temp_working_dir, ignore_errors=True)
 
@@ -2623,6 +2583,13 @@ def warp_raster(
     base_raster_info = get_raster_info(base_raster_path)
     if target_projection_wkt is None:
         target_projection_wkt = base_raster_info['projection_wkt']
+    if None in base_raster_info['nodata']:
+        target_nodata = choose_nodata(base_raster_info['numpy_type'])
+        LOGGER.warning(f'One or more bands in {base_raster_path} do not have '
+                       'a designated NoData value. The output warped raster '
+                       f'will be assigned a NoData value of {target_nodata}')
+    else:
+        target_nodata = base_raster_info['nodata'][0]
 
     if vector_mask_options is not None:
         warnings.warn('The vector_mask_options parameter is deprecated and '
@@ -2736,6 +2703,7 @@ def warp_raster(
         outputBoundsSRS=target_projection_wkt,
         srcSRS=base_projection_wkt,
         dstSRS=target_projection_wkt,
+        dstNodata=target_nodata,
         multithread=True if warp_options else False,
         warpOptions=warp_options,
         overviewLevel=use_overview_level,

--- a/src/pygeoprocessing/geoprocessing.py
+++ b/src/pygeoprocessing/geoprocessing.py
@@ -823,6 +823,10 @@ def align_and_resize_raster_stack(
     clipping or resizing the rasters to intersected, unioned, or equivocated
     bounding boxes of all the raster and vector input.
 
+    Note: If any bands in rasters in ``base_raster_path_list`` do not have a
+    defined NoData value, a suitable value will be chosen for all bands in
+    that raster based on its datatype.
+
     Args:
         base_raster_path_list (sequence): a sequence of base raster paths that
             will be transformed and will be used to determine the target
@@ -2485,6 +2489,10 @@ def warp_raster(
         osr_axis_mapping_strategy=DEFAULT_OSR_AXIS_MAPPING_STRATEGY):
     """Resize/resample raster to desired pixel size, bbox and projection.
 
+    Note: If any band in ``base_raster_path`` does not have a defined NoData
+    value, a suitable value will be chosen for all bands based on the
+    raster's datatype.
+
     Args:
         base_raster_path (string): path to base raster. Paths may use any
             GDAL-supported scheme, including virtual file system /vsi schemes.
@@ -2583,13 +2591,15 @@ def warp_raster(
     base_raster_info = get_raster_info(base_raster_path)
     if target_projection_wkt is None:
         target_projection_wkt = base_raster_info['projection_wkt']
+    source_nodata = " ".join(str(x) for x in base_raster_info['nodata'])
     if None in base_raster_info['nodata']:
         target_nodata = choose_nodata(base_raster_info['numpy_type'])
         LOGGER.warning(f'One or more bands in {base_raster_path} do not have '
-                       'a designated NoData value. The output warped raster '
-                       f'will be assigned a NoData value of {target_nodata}')
+                       'a designated NoData value. All bands in the output '
+                       'warped raster will be assigned a NoData value '
+                       f'of {target_nodata}.')
     else:
-        target_nodata = base_raster_info['nodata'][0]
+        target_nodata = " ".join(str(x) for x in base_raster_info['nodata'])
 
     if vector_mask_options is not None:
         warnings.warn('The vector_mask_options parameter is deprecated and '
@@ -2703,6 +2713,7 @@ def warp_raster(
         outputBoundsSRS=target_projection_wkt,
         srcSRS=base_projection_wkt,
         dstSRS=target_projection_wkt,
+        srcNodata=source_nodata,
         dstNodata=target_nodata,
         multithread=True if warp_options else False,
         warpOptions=warp_options,

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2585,6 +2585,38 @@ class TestGeoprocessing(unittest.TestCase):
         numpy.testing.assert_array_equal(
             numpy.ones((4, 4), pixel_a_matrix.dtype), target_array)
 
+    def test_align_and_resize_raster_stack_no_defined_nodata(self):
+        """Test that align and resize sets nodata if not defined."""
+        arr = numpy.arange(16).reshape(4, 4)
+        print(arr)
+
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(26910)
+        input_raster_path = os.path.join(self.workspace_dir, 'test.tif')
+        pygeoprocessing.numpy_array_to_raster(
+            arr.astype(numpy.int16), target_nodata=None,
+            pixel_size=(10, -10), origin=(0, 0),
+            projection_wkt=srs.ExportToWkt(),
+            target_path=input_raster_path)
+
+        output_raster_path = os.path.join(self.workspace_dir, 'test_align.tif')
+        pygeoprocessing.align_and_resize_raster_stack(
+            [input_raster_path],
+            [output_raster_path],
+            ['near'],
+            (10, -10),
+            [-10, -20, 20, 0],
+            # this target bounding box extends beyond extent of input raster
+            # (input raster's bbox is [0, -40, 40, 0])
+            base_vector_path_list=None,
+            raster_align_index=None, mask_options=None,
+            vector_mask_options=None)
+
+        output_array = pygeoprocessing.raster_to_numpy_array(
+            output_raster_path)
+        expected_output_array = numpy.array([[32767, 0, 1], [32767, 4, 5]])
+        numpy.testing.assert_allclose(output_array, expected_output_array)
+
     def test_raster_calculator(self):
         """PGP.geoprocessing: raster_calculator identity test."""
         pixel_matrix = numpy.ones((5, 5), numpy.int16)

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2653,7 +2653,7 @@ class TestGeoprocessing(unittest.TestCase):
             )
 
         self.assertTrue(
-            any("some bands with a defined nodata value and some bands without"
+            any("One or more bands"
                 in msg for msg in cm.output),
             f"Expected warning not found in logs: {cm.output}")
 

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2147,6 +2147,52 @@ class TestGeoprocessing(unittest.TestCase):
             target_raster_path)
         numpy.testing.assert_allclose(target_array, expected_matrix)
 
+    def test_warp_raster_mixed_nodata_warns(self):
+        """Test warning if 1 band in multiband raster has no defined nodata.
+
+        Test that a warning is raised if a multiband raster with one band
+        that has a defined nodata value and one band that does not have a
+        defined nodata value is passed to warp_raster. Test output has
+        auto-defined NoData, not input NoData.
+        """
+
+        raster_path = os.path.join(self.workspace_dir, 'multi.tif')
+        driver = gdal.GetDriverByName('GTiff')
+        raster = driver.Create(raster_path, 4, 4, 2, gdal.GDT_Int16)
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(26910)
+        raster.SetProjection(srs.ExportToWkt())
+        raster.SetGeoTransform((0, 10, 0, 0, 0, -10))
+        arr = numpy.arange(16).reshape(4, 4)
+        arr[0, 0] = -9999
+        band1 = raster.GetRasterBand(1)
+        band2 = raster.GetRasterBand(2)
+        band1.WriteArray(arr)
+        band2.WriteArray(arr)
+        raster = None
+
+        vrt_path = os.path.join(self.workspace_dir, 'multi.vrt')
+        gdal.BuildVRT(vrt_path, [raster_path])
+        vrt = gdal.Open(vrt_path, gdal.GA_Update)
+        vrt.GetRasterBand(2).SetNoDataValue(-9999)
+        # leave band 1 without nodata
+        vrt = None
+
+        output_raster_path = os.path.join(self.workspace_dir, 'out.tif')
+        with self.assertLogs(level='WARNING') as cm:
+            pygeoprocessing.warp_raster(vrt_path, (10, -10),
+                                        output_raster_path, 'near')
+
+        self.assertTrue(
+            any("One or more bands"
+                in msg for msg in cm.output),
+            f"Expected warning not found in logs: {cm.output}")
+
+        arr[0, 0] = 32767 # expected output has default NoData for int16
+        actual_array = pygeoprocessing.raster_to_numpy_array(
+            output_raster_path, 2)
+        numpy.testing.assert_allclose(actual_array, arr)
+
     def test_align_and_resize_raster_stack_bad_values(self):
         """PGP.geoprocessing: align/resize raster bad base values."""
         pixel_a_matrix = numpy.ones((5, 5), numpy.int16)
@@ -2612,50 +2658,6 @@ class TestGeoprocessing(unittest.TestCase):
             output_raster_path)
         expected_output_array = numpy.array([[32767, 0, 1], [32767, 4, 5]])
         numpy.testing.assert_allclose(output_array, expected_output_array)
-
-    def test_align_and_resize_raster_stack_mixed_nodata_warns(self):
-        """Test warning if 1 band in multiband raster has no defined nodata.
-
-        Test that a warning is raised if a multiband raster with one band
-        that has a defined nodata value and one band that does not have a
-        defined nodata value is passed to align_and_resize_raster_stack.
-        """
-
-        raster_path = os.path.join(self.workspace_dir, 'multi.tif')
-        driver = gdal.GetDriverByName('GTiff')
-        raster = driver.Create(raster_path, 4, 4, 2, gdal.GDT_Int16)
-        srs = osr.SpatialReference()
-        srs.ImportFromEPSG(26910)
-        raster.SetProjection(srs.ExportToWkt())
-        raster.SetGeoTransform((0, 10, 0, 0, 0, -10))
-        arr = numpy.arange(16).reshape(4, 4)
-        band1 = raster.GetRasterBand(1)
-        band2 = raster.GetRasterBand(2)
-        band1.WriteArray(arr)
-        band2.WriteArray(arr)
-        raster = None
-
-        vrt_path = os.path.join(self.workspace_dir, 'multi.vrt')
-        gdal.BuildVRT(vrt_path, [raster_path])
-        vrt = gdal.Open(vrt_path, gdal.GA_Update)
-        vrt.GetRasterBand(2).SetNoDataValue(-9999)
-        # leave band 1 without nodata
-        vrt = None
-
-        output_raster_path = os.path.join(self.workspace_dir, 'out.tif')
-        with self.assertLogs(level='WARNING') as cm:
-            pygeoprocessing.align_and_resize_raster_stack(
-                [vrt_path],
-                [output_raster_path],
-                ['near'],
-                (10, -10),
-                [-10, -20, 20, 0]
-            )
-
-        self.assertTrue(
-            any("One or more bands"
-                in msg for msg in cm.output),
-            f"Expected warning not found in logs: {cm.output}")
 
     def test_raster_calculator(self):
         """PGP.geoprocessing: raster_calculator identity test."""

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2585,10 +2585,9 @@ class TestGeoprocessing(unittest.TestCase):
         numpy.testing.assert_array_equal(
             numpy.ones((4, 4), pixel_a_matrix.dtype), target_array)
 
-    def test_align_and_resize_raster_stack_no_defined_nodata(self):
-        """Test that align and resize sets nodata if not defined."""
+    def test_align_and_resize_raster_stack_no_set_nodata_multiband(self):
+        """Test align_and_resize sets nodata if not defined for input."""
         arr = numpy.arange(16).reshape(4, 4)
-        print(arr)
 
         srs = osr.SpatialReference()
         srs.ImportFromEPSG(26910)
@@ -2605,17 +2604,58 @@ class TestGeoprocessing(unittest.TestCase):
             [output_raster_path],
             ['near'],
             (10, -10),
-            [-10, -20, 20, 0],
+            [-10, -20, 20, 0])
             # this target bounding box extends beyond extent of input raster
             # (input raster's bbox is [0, -40, 40, 0])
-            base_vector_path_list=None,
-            raster_align_index=None, mask_options=None,
-            vector_mask_options=None)
 
         output_array = pygeoprocessing.raster_to_numpy_array(
             output_raster_path)
         expected_output_array = numpy.array([[32767, 0, 1], [32767, 4, 5]])
         numpy.testing.assert_allclose(output_array, expected_output_array)
+
+    def test_align_and_resize_raster_stack_mixed_nodata_warns(self):
+        """Test warning if 1 band in multiband raster has no defined nodata.
+
+        Test that a warning is raised if a multiband raster with one band
+        that has a defined nodata value and one band that does not have a
+        defined nodata value is passed to align_and_resize_raster_stack.
+        """
+
+        raster_path = os.path.join(self.workspace_dir, 'multi.tif')
+        driver = gdal.GetDriverByName('GTiff')
+        raster = driver.Create(raster_path, 4, 4, 2, gdal.GDT_Int16)
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(26910)
+        raster.SetProjection(srs.ExportToWkt())
+        raster.SetGeoTransform((0, 10, 0, 0, 0, -10))
+        arr = numpy.arange(16).reshape(4, 4)
+        band1 = raster.GetRasterBand(1)
+        band2 = raster.GetRasterBand(2)
+        band1.WriteArray(arr)
+        band2.WriteArray(arr)
+        raster = None
+
+        vrt_path = os.path.join(self.workspace_dir, 'multi.vrt')
+        gdal.BuildVRT(vrt_path, [raster_path])
+        vrt = gdal.Open(vrt_path, gdal.GA_Update)
+        vrt.GetRasterBand(2).SetNoDataValue(-9999)
+        # leave band 1 without nodata
+        vrt = None
+
+        output_raster_path = os.path.join(self.workspace_dir, 'out.tif')
+        with self.assertLogs(level='WARNING') as cm:
+            pygeoprocessing.align_and_resize_raster_stack(
+                [vrt_path],
+                [output_raster_path],
+                ['near'],
+                (10, -10),
+                [-10, -20, 20, 0]
+            )
+
+        self.assertTrue(
+            any("some bands with a defined nodata value and some bands without"
+                in msg for msg in cm.output),
+            f"Expected warning not found in logs: {cm.output}")
 
     def test_raster_calculator(self):
         """PGP.geoprocessing: raster_calculator identity test."""

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -2188,7 +2188,15 @@ class TestGeoprocessing(unittest.TestCase):
                 in msg for msg in cm.output),
             f"Expected warning not found in logs: {cm.output}")
 
-        arr[0, 0] = 32767 # expected output has default NoData for int16
+        # check that first pixel in band 1 is still -9999 (because that band
+        # had no defined NoData)
+        actual_array = pygeoprocessing.raster_to_numpy_array(
+            output_raster_path)
+        numpy.testing.assert_allclose(actual_array, arr)
+
+        # check that first pixel in band 2 was converted to appropriate Nodata
+        # value for a int16 raster
+        arr[0, 0] = 32767
         actual_array = pygeoprocessing.raster_to_numpy_array(
             output_raster_path, 2)
         numpy.testing.assert_allclose(actual_array, arr)


### PR DESCRIPTION
The initial impetus for this PR was: if a raster input to `align_and_resize_raster_stack` does not have a defined `NoData` value, PGP should automatically pick one. We decided to handle this within `warp_raster`, which is called by `align_and_resize_raster_stack`. `warp_raster` now also logs a warning if any band in a raster input has an undefined NoData value. For multiband rasters, if one band in the raster has a NoData value of `None`, all bands will be reassigned a NoData value picked by `pygeoprocessing.choose_nodata`.

~~## Steps:~~
~~1. Detects rasters with missing `NoData` values~~
~~2. Creates a temporary VRT for those rasters and assigns a `NoData` value using `choose_nodata` (this is to avoid modifying a user's original data)~~
~~3. Uses the temporary VRT path during warping/alignment~~
~~4. Logs different warnings if (a) a raster has no `NoData` defined on any band, or (b) a multiband raster has `NoData` defined on some bands but not others, in which case a single `NoData` value is applied to all bands in the temporary VRT~~

Fixes: #476