### PR TITLE
Add `pygeoprocessing.include_dir()` and lazily import the dependency tree

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@ Release History
 
 Unreleased Changes
 ------------------
+* Added a new function, ``pygeoprocessing.get_include()`` that returns the
+  path to the ``extensions`` folder within your pygeoprocessing install.
+  To make compilation on cross-compiled systems easier, all top-level imports
+  from the ``pygeoprocessing`` namespace are lazily loaded.
+  https://github.com/natcap/pygeoprocessing/issues/480
 * ``warp_raster`` will now automatically assign an appropriate NoData value
   to any input raster without one defined. This fixes a bug where
   ``align_and_resize_raster_stack`` would pad rasters that were smaller

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,9 @@ Unreleased Changes
 * Added a new function, ``pygeoprocessing.get_include()`` that returns the
   path to the ``extensions`` folder within your pygeoprocessing install.
   To make compilation on cross-compiled systems easier, all top-level imports
-  from the ``pygeoprocessing`` namespace are lazily loaded.
+  from the ``pygeoprocessing`` namespace are lazily loaded through the
+  ``lazy-loader`` python package.  As a result of this change, ``lazy-loader``
+  is now a dependency and python 3.9 or later is required.
   https://github.com/natcap/pygeoprocessing/issues/480
 * ``warp_raster`` will now automatically assign an appropriate NoData value
   to any input raster without one defined. This fixes a bug where

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pygeoprocessing"
 description = "PyGeoprocessing: Geoprocessing routines for GIS"
-requires-python = ">=3.6"
+requires-python = ">=3.9"
 license = "BSD-3-Clause"
 license-files = ["LICENSE.txt"]
 maintainers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ numpy>=1.10.1
 Rtree>=0.8.3
 scipy>=0.14.1,!=0.19.1
 Shapely>=1.6.4
-importlib_metadata  # technically only required on python < 3.8; easier to install with conda across all versions
+lazy-loader

--- a/src/pygeoprocessing/__init__.py
+++ b/src/pygeoprocessing/__init__.py
@@ -9,12 +9,9 @@ import os
 import importlib
 import functools
 
-try:
-    from importlib.metadata import PackageNotFoundError
-    from importlib.metadata import version
-except ImportError:
-    from importlib_metadata import version
-    from importlib_metadata import PackageNotFoundError
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version
+import lazy_loader
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.NullHandler())  # silence logging by default
@@ -31,117 +28,59 @@ except PackageNotFoundError:
     pass
 
 
-def _lazy_import(modulename):
-    """Lazily import a module.
-
-    The returned modbule object will not actually be imported until a module
-    attribute is accessed.
-
-    Args:
-        modulename (str): The name of the module to load.  If the modulename
-            starts with a ".", it will be treated as a relative import.
-
-    Returns:
-        An ``importlib.util._LazyModule`` instance.
-    """
-    # Locate the module's specification.
-    # Handle the case where a relative import is requested.
-    package = None
-    if modulename.startswith('.'):
-        package = __package__
-    spec = importlib.util.find_spec(modulename, package=package)
-    if spec is None:
-        raise ModuleNotFoundError(f"No module named '{module}'")
-
-    # Wrap the existing loader with LazyLoader
-    loader = importlib.util.LazyLoader(spec.loader)
-    spec.loader = loader
-
-    # Create the module object from the modified spec
-    module = importlib.util.module_from_spec(spec)
-
-    # Cache it in sys.modules so future traditional imports pull this reference
-    sys.modules[modulename] = module
-
-    # Execute the module proxy shell
-    loader.exec_module(module)
-    return module
-
-
-geoprocessing = _lazy_import(".geoprocessing")
-_exposed_attrs = {
-    ".geoprocessing": [
-        "_assert_is_valid_pixel_size",
-        "align_and_resize_raster_stack",
-        "align_bbox",
-        "array_equals_nodata",
-        "build_overviews",
-        "calculate_disjoint_polygon_set",
-        "choose_dtype",
-        "choose_nodata",
-        "convolve_2d",
-        "create_raster_from_bounding_box",
-        "create_raster_from_vector_extents",
-        "distance_transform_edt",
-        "get_gis_type",
-        "get_raster_info",
-        "get_vector_info",
-        "interpolate_points",
-        "iterblocks",
-        "mask_raster",
-        "merge_bounding_box_list",
-        "new_raster_from_base",
-        "numpy_array_to_raster",
-        "raster_calculator",
-        "raster_map",
-        "raster_reduce",
-        "raster_to_numpy_array",
-        "rasterize",
-        "ReclassificationMissingValuesError",
-        "reclassify_raster",
-        "reproject_vector",
-        "shapely_geometry_to_vector",
-        "stitch_rasters",
-        "transform_bounding_box",
-        "warp_raster",
-        "zonal_statistics",
-    ],
-    ".slurm_utils": [
-        "log_warning_if_gdal_will_exhaust_slurm_memory",
-    ],
-    ".utils": [
-         "GDALUseExceptions",
-         "gdal_use_exceptions",
-    ],
-    ".geoprocessing_core": [
-        "calculate_slope",
-        "raster_band_percentile",
-    ],
-}
-_reverse_module_map = {}  # funcname: modulename
-__all__ = tuple()
-for _modulename, _member_funcnames in _exposed_attrs.items():
-    for _funcname in _member_funcnames:
-        _reverse_module_map[_funcname] = _modulename
-        __all__ += (_funcname,)
-
-# Lazily load attributes that are defined in __all__.
-def __getattr__(name: str):
-    if name in __all__:
-        package = None
-        module = _reverse_module_map[name]
-        if module.startswith('.'):
-            package = __package__
-        imported_module = importlib.import_module(module, package=package)
-        return getattr(imported_module, name)
-    raise AttributeError(name)
-
-
-# Our lazy attribute loading means that items we want to lazily load won't
-# be able to be inspected easily with dir().  Add them back.
-def __dir__():
-    _default_attrs = list(globals().keys())
-    return sorted(_default_attrs + list(__all__))
+__getattr__, __dir__, __all__ = lazy_loader.attach(
+    __name__,
+    submodules=['geoprocessing'],
+    submod_attrs={
+        "geoprocessing": [
+            "_assert_is_valid_pixel_size",
+            "align_and_resize_raster_stack",
+            "align_bbox",
+            "array_equals_nodata",
+            "build_overviews",
+            "calculate_disjoint_polygon_set",
+            "choose_dtype",
+            "choose_nodata",
+            "convolve_2d",
+            "create_raster_from_bounding_box",
+            "create_raster_from_vector_extents",
+            "distance_transform_edt",
+            "get_gis_type",
+            "get_raster_info",
+            "get_vector_info",
+            "interpolate_points",
+            "iterblocks",
+            "mask_raster",
+            "merge_bounding_box_list",
+            "new_raster_from_base",
+            "numpy_array_to_raster",
+            "raster_calculator",
+            "raster_map",
+            "raster_reduce",
+            "raster_to_numpy_array",
+            "rasterize",
+            "ReclassificationMissingValuesError",
+            "reclassify_raster",
+            "reproject_vector",
+            "shapely_geometry_to_vector",
+            "stitch_rasters",
+            "transform_bounding_box",
+            "warp_raster",
+            "zonal_statistics",
+        ],
+        "slurm_utils": [
+            "log_warning_if_gdal_will_exhaust_slurm_memory",
+        ],
+        "utils": [
+            "GDALUseExceptions",
+            "gdal_use_exceptions",
+        ],
+        "geoprocessing_core": [
+            "calculate_slope",
+            "raster_band_percentile",
+        ],
+    }
+)
 
 
 def get_include():

--- a/src/pygeoprocessing/__init__.py
+++ b/src/pygeoprocessing/__init__.py
@@ -3,14 +3,9 @@
 __init__ module imports all the geoprocessing functions into this namespace.
 """
 import logging
-import sys
-import types
 import os
-import importlib
-import functools
+from importlib.metadata import PackageNotFoundError, version
 
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version
 import lazy_loader
 
 LOGGER = logging.getLogger(__name__)

--- a/src/pygeoprocessing/__init__.py
+++ b/src/pygeoprocessing/__init__.py
@@ -34,7 +34,7 @@ except PackageNotFoundError:
 def _lazy_import(modulename):
     """Lazily import a module.
 
-    The returned modbule object will not actually be imported until a module
+    The returned module object will not actually be imported until a module
     attribute is accessed.
 
     Args:

--- a/src/pygeoprocessing/__init__.py
+++ b/src/pygeoprocessing/__init__.py
@@ -3,8 +3,11 @@
 __init__ module imports all the geoprocessing functions into this namespace.
 """
 import logging
+import sys
 import types
 import os
+import importlib
+import functools
 
 try:
     from importlib.metadata import PackageNotFoundError
@@ -12,67 +15,6 @@ try:
 except ImportError:
     from importlib_metadata import version
     from importlib_metadata import PackageNotFoundError
-
-from . import geoprocessing
-from .geoprocessing import _assert_is_valid_pixel_size
-from .geoprocessing import align_and_resize_raster_stack
-from .geoprocessing import align_bbox
-from .geoprocessing import array_equals_nodata
-from .geoprocessing import build_overviews
-from .geoprocessing import calculate_disjoint_polygon_set
-from .geoprocessing import choose_dtype
-from .geoprocessing import choose_nodata
-from .geoprocessing import convolve_2d
-from .geoprocessing import create_raster_from_bounding_box
-from .geoprocessing import create_raster_from_vector_extents
-from .geoprocessing import distance_transform_edt
-from .geoprocessing import get_gis_type
-from .geoprocessing import get_raster_info
-from .geoprocessing import get_vector_info
-from .geoprocessing import interpolate_points
-from .geoprocessing import iterblocks
-from .geoprocessing import mask_raster
-from .geoprocessing import merge_bounding_box_list
-from .geoprocessing import new_raster_from_base
-from .geoprocessing import numpy_array_to_raster
-from .geoprocessing import raster_calculator
-from .geoprocessing import raster_map
-from .geoprocessing import raster_reduce
-from .geoprocessing import raster_to_numpy_array
-from .geoprocessing import rasterize
-from .geoprocessing import ReclassificationMissingValuesError
-from .geoprocessing import reclassify_raster
-from .geoprocessing import reproject_vector
-from .geoprocessing import shapely_geometry_to_vector
-from .geoprocessing import stitch_rasters
-from .geoprocessing import transform_bounding_box
-from .geoprocessing import warp_raster
-from .geoprocessing import zonal_statistics
-from .geoprocessing_core import calculate_slope
-from .geoprocessing_core import raster_band_percentile
-from .slurm_utils import log_warning_if_gdal_will_exhaust_slurm_memory
-from .utils import GDALUseExceptions
-from .utils import gdal_use_exceptions
-
-try:
-    __version__ = version('pygeoprocessing')
-except PackageNotFoundError:
-    # package is not installed
-    pass
-
-
-# Programmatically defining __all__ based on what's been imported.
-# Thus, the imports are the source of truth for __all__.
-__all__ = ('calculate_slope', 'raster_band_percentile',
-           'ReclassificationMissingValuesError')
-exclude_set = {'log_warning_if_gdal_will_exhaust_slurm_memory'}
-for attrname in [k for k in locals().keys()]:
-    try:
-        if (isinstance(getattr(geoprocessing, attrname), types.FunctionType)
-                and attrname not in exclude_set):
-            __all__ += (attrname,)
-    except AttributeError:
-        pass
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.NullHandler())  # silence logging by default
@@ -82,8 +24,104 @@ UNKNOWN_TYPE = 0
 RASTER_TYPE = 1
 VECTOR_TYPE = 2
 
-# Check GDAL's cache max vs SLURM memory if we're on slurm.
-log_warning_if_gdal_will_exhaust_slurm_memory()
+try:
+    __version__ = version('pygeoprocessing')
+except PackageNotFoundError:
+    # package is not installed
+    pass
+
+
+def _lazy_import(modulename):
+    # Locate the module's specification
+    package = None
+    if modulename.startswith('.'):
+        package = __package__
+    spec = importlib.util.find_spec(modulename, package=package)
+    if spec is None:
+        raise ModuleNotFoundError(f"No module named '{module}'")
+
+    # Wrap the existing loader with LazyLoader
+    loader = importlib.util.LazyLoader(spec.loader)
+    spec.loader = loader
+
+    # Create the module object from the modified spec
+    module = importlib.util.module_from_spec(spec)
+
+    # Cache it in sys.modules so future traditional imports pull this reference
+    sys.modules[modulename] = module
+
+    # Execute the module proxy shell
+    loader.exec_module(module)
+    return module
+
+
+geoprocessing = _lazy_import(".geoprocessing")
+_exposed_attrs = {
+    ".geoprocessing": [
+        "_assert_is_valid_pixel_size",
+        "align_and_resize_raster_stack",
+        "align_bbox",
+        "array_equals_nodata",
+        "build_overviews",
+        "calculate_disjoint_polygon_set",
+        "choose_dtype",
+        "choose_nodata",
+        "convolve_2d",
+        "create_raster_from_bounding_box",
+        "create_raster_from_vector_extents",
+        "distance_transform_edt",
+        "get_gis_type",
+        "get_raster_info",
+        "get_vector_info",
+        "interpolate_points",
+        "iterblocks",
+        "mask_raster",
+        "merge_bounding_box_list",
+        "new_raster_from_base",
+        "numpy_array_to_raster",
+        "raster_calculator",
+        "raster_map",
+        "raster_reduce",
+        "raster_to_numpy_array",
+        "rasterize",
+        "ReclassificationMissingValuesError",
+        "reclassify_raster",
+        "reproject_vector",
+        "shapely_geometry_to_vector",
+        "stitch_rasters",
+        "transform_bounding_box",
+        "warp_raster",
+        "zonal_statistics",
+    ],
+    ".slurm_utils": [
+        "log_warning_if_gdal_will_exhaust_slurm_memory",
+    ],
+    ".utils": [
+         "GDALUseExceptions",
+         "gdal_use_exceptions",
+    ],
+    ".geoprocessing_core": [
+        "calculate_slope",
+        "raster_band_percentile",
+    ],
+}
+_reverse_module_map = {}  # funcname: modulename
+__all__ = tuple()
+for _modulename, _member_funcnames in _exposed_attrs.items():
+    for _funcname in _member_funcnames:
+        _reverse_module_map[_funcname] = _modulename
+        __all__ += (_funcname,)
+
+# Lazily load attributes that are defined in __all__.
+def __getattr__(name: str):
+    if name in __all__:
+        package = None
+        module = _reverse_module_map[name]
+        if module.startswith('.'):
+            package = __package__
+        imported_module = importlib.import_module(module, package=package)
+        return getattr(imported_module, name)
+    raise AttributeError(name)
 
 
 def get_include():

--- a/src/pygeoprocessing/__init__.py
+++ b/src/pygeoprocessing/__init__.py
@@ -32,7 +32,20 @@ except PackageNotFoundError:
 
 
 def _lazy_import(modulename):
-    # Locate the module's specification
+    """Lazily import a module.
+
+    The returned modbule object will not actually be imported until a module
+    attribute is accessed.
+
+    Args:
+        modulename (str): The name of the module to load.  If the modulename
+            starts with a ".", it will be treated as a relative import.
+
+    Returns:
+        An ``importlib.util._LazyModule`` instance.
+    """
+    # Locate the module's specification.
+    # Handle the case where a relative import is requested.
     package = None
     if modulename.startswith('.'):
         package = __package__

--- a/src/pygeoprocessing/__init__.py
+++ b/src/pygeoprocessing/__init__.py
@@ -4,6 +4,7 @@ __init__ module imports all the geoprocessing functions into this namespace.
 """
 import logging
 import types
+import os
 
 try:
     from importlib.metadata import PackageNotFoundError
@@ -83,3 +84,11 @@ VECTOR_TYPE = 2
 
 # Check GDAL's cache max vs SLURM memory if we're on slurm.
 log_warning_if_gdal_will_exhaust_slurm_memory()
+
+
+def get_include():
+    """Return the directory that includes the pygeoprocessing *.h header files.
+
+    Returns:
+        The string path to the header files location."""
+    return os.path.join(os.path.dirname(__file__), 'extensions')

--- a/src/pygeoprocessing/__init__.py
+++ b/src/pygeoprocessing/__init__.py
@@ -124,6 +124,13 @@ def __getattr__(name: str):
     raise AttributeError(name)
 
 
+# Our lazy attribute loading means that items we want to lazily load won't
+# be able to be inspected easily with dir().  Add them back.
+def __dir__():
+    _default_attrs = list(globals().keys())
+    return sorted(_default_attrs + list(__all__))
+
+
 def get_include():
     """Return the directory that includes the pygeoprocessing *.h header files.
 

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -144,6 +144,10 @@ class TestGeoprocessing(unittest.TestCase):
         for attrname in pygeoprocessing.__all__:
             try:
                 func = getattr(pygeoprocessing, attrname)
+
+                # __all__ can be a module, e.g. geoprocessing.
+                if isinstance(func, types.ModuleType):
+                    continue
                 try:
                     _ = getattr(func, '__call__')
                 except AttributeError:

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -6102,3 +6102,14 @@ class TestGeoprocessing(unittest.TestCase):
                 [500000, -50, 0, 5000000, 0, 50],
                 [499999, 5000001, 499999, 5000001]),
             [499950, 5000000, 500000, 5000050])
+
+    def test_get_include(self):
+        """PGP: test get_include()."""
+        # Check the value is what we expect
+        self.assertEqual(
+            pygeoprocessing.get_include(),
+            os.path.join(pygeoprocessing.__path__[0], "extensions"),
+        )
+
+        # Confirm that the include dir exists
+        self.assertTrue(os.path.isdir(pygeoprocessing.get_include()))


### PR DESCRIPTION
This PR adds a new function, `pygeoprocessing.get_include()` that returns the path to the folder that should be passed to a compiler when compiling projects like `natcap.invest` against pygeoprocessing.

Although this feature by itself is useful, the experience of working in cross-compiled environments like conda-forge (https://github.com/conda-forge/natcap.invest-feedstock/pull/60) has also made it clear that it is _very_ useful to avoid importing pygeoprocessing's whole dependency tree at compile time.  To try to resolve this, I have updated the import functionality in this PR so that imports are lazily loaded only when attributes are actually called.  This behavior is discouraged in the python docs because import-time errors won't show up as readily, but I think the tradeoff here is worth it.   From an outside view, no functionality should change as a result of this PR except when, exactly, a module is imported.

Fixes #480 